### PR TITLE
Host and prefix path validation inline with KEP

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,25 @@ The goal of this project is to act as an executable specification in the form of
 
 The conformance test suite will both ensure consistency across implementations, as well as simplify the work needed for other implementations to conform to the specification. The test suite can also be viewed through human readable descriptions of what it is testing so that implementers can understand the tests without reading source code.
 
+Currently, the `ingress-controller-conformance` supports the `Ingress` resource from [`networking.k8s.io/v1beta1` API](https://kubernetes.io/docs/concepts/services-networking/ingress/), with the goal to serve as a benchmark for the Ingress resource under the `networking.k8s.io/v1` API and the [Ingress/Service V2 evolution](https://kubernetes-sigs.github.io/service-apis/).
+
+## Coverage
+
+The current suite of tests covers the following features of the `Ingress` resource:
+- Plain text HTTP/1.1 requests
+- Exact and wildcard Host rules
+- Prefix path matches rules
+- No rules single-service matching
+
+Future tests should align with the Ingress resource specification and support:
+- Requests not matching any ingress rules should result in `404 Not Found` responses. Currently, all unmatched requests will fallback to a catch-all route.
+- Multiple exposed ingress addresses and ports.
+- Ingress resources with backend services across different namespaces.
+- HTTPS with SSL termination and SNI at the ingress-controller.
+- Support different path match modes for `networking.k8s.io/v1`: "exact" and "prefix" path types.
+- Other TCP protocols and UDP.
+- Load-balancing between multiple upstream instances. 
+
 ## Running
 
 ### CLI
@@ -30,10 +49,7 @@ List, in a human-readable form, all Ingress verifications
 ```
 $ ./ingress-controller-conformance list
 - Ingress with host rule should send traffic to the correct backend service (host-rules)
-- [SAMPLE] Ingress with path rule without a trailing slash should send traffic to the correct backend service, and preserve the original request path (path-rules-foo)
-- [SAMPLE] Ingress with path rule without a trailing slash should send traffic to the correct backend service, and preserve the original request including sub-paths (path-rules-foo-trailing)
-- [SAMPLE] Ingress with path rule with a trailing slash should send traffic to the correct backend service, and preserve the original request path (path-rules-bar)
-- [SAMPLE] Ingress with path rule with a trailing slash should send traffic to the correct backend service, and preserve the original request including sub-paths and double '/' (path-rules-bar-subpath)
+- [...]
 - Ingress with no rules should send traffic to the correct backend service (single-service)
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The current suite of implemented tests covers the following features of the `Ing
 - Plain text HTTP/1.1 requests
 - Exact and wildcard Host rules
 - Prefix path matches rules
-- No rules single-service delegation
+- No rules default-backend delegation
 
 Future tests should align with the Ingress resource specification, and support:
 - HTTP requests without any matching ingress rules should result in a standard `404 Not Found` responses. Currently, all unmatched requests will fallback to the default-backend.
@@ -51,7 +51,7 @@ Lists, in a human-readable form, all Ingress verifications
 $ ./ingress-controller-conformance list
 - Ingress with host rule should send traffic to the correct backend service (host-rules)
 - [...]
-- Ingress with no rules should send traffic to the correct backend service (single-service)
+- [...]
 ```
 
 #### Verify
@@ -68,13 +68,7 @@ Running 'path-rules-foo' verifications...
 Running 'path-rules-foo-trailing' verifications...
         1) Assertion failed: Expected the request path would be '/foo/' but was '//'
   Check failed: path-rules-foo-trailing
-Running 'path-rules-bar' verifications...
-        1) Assertion failed: Expected the request path would be '/bar/' but was '/'
-  Check failed: path-rules-bar
-Running 'path-rules-bar-subpath' verifications...
-        1) Assertion failed: Expected the request path would be '/bar//bershop' but was '//bershop'
-  Check failed: path-rules-bar-subpath
-Running 'single-service' verifications...
+[...]
 --- Verification completed ---
 3 checks passed! 4 failures!
 in 1.777148914s

--- a/README.md
+++ b/README.md
@@ -4,24 +4,25 @@ The goal of this project is to act as an executable specification in the form of
 
 The conformance test suite will both ensure consistency across implementations, as well as simplify the work needed for other implementations to conform to the specification. The test suite can also be viewed through human readable descriptions of what it is testing so that implementers can understand the tests without reading source code.
 
-Currently, the `ingress-controller-conformance` supports the `Ingress` resource from [`networking.k8s.io/v1beta1` API](https://kubernetes.io/docs/concepts/services-networking/ingress/), with the goal to serve as a benchmark for the Ingress resource under the `networking.k8s.io/v1` API and the [Ingress/Service V2 evolution](https://kubernetes-sigs.github.io/service-apis/).
+Currently, the `ingress-controller-conformance` supports the `Ingress` resource from [`networking.k8s.io/v1beta1` API](https://kubernetes.io/docs/concepts/services-networking/ingress/), with the desire to serve as a benchmark for the Ingress resource under the [`networking.k8s.io/v1` API](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/20190125-ingress-api-group.md) and the [Ingress/Service V2 evolution](https://kubernetes-sigs.github.io/service-apis/) proposals.
 
 ## Coverage
 
-The current suite of tests covers the following features of the `Ingress` resource:
+The current suite of implemented tests covers the following features of the `Ingress` resource:
 - Plain text HTTP/1.1 requests
 - Exact and wildcard Host rules
 - Prefix path matches rules
-- No rules single-service matching
+- No rules single-service delegation
 
-Future tests should align with the Ingress resource specification and support:
-- Requests not matching any ingress rules should result in `404 Not Found` responses. Currently, all unmatched requests will fallback to a catch-all route.
+Future tests should align with the Ingress resource specification, and support:
+- HTTP requests without any matching ingress rules should result in a standard `404 Not Found` responses. Currently, all unmatched requests will fallback to the default-backend.
 - Multiple exposed ingress addresses and ports.
 - Ingress resources with backend services across different namespaces.
-- HTTPS with SSL termination and SNI at the ingress-controller.
-- Support different path match modes for `networking.k8s.io/v1`: "exact" and "prefix" path types.
-- Other TCP protocols and UDP.
-- Load-balancing between multiple upstream instances. 
+- HTTPS with SSL termination and SNI.
+- Support different path match modes: "exact", "prefix", and "regex" path types.
+- Other TCP protocols backend types.
+- Load-balancing between multiple upstream instances.
+- Assert commonly implemented extension points in various ingress-controllers such as gzip compression and keep-alive connections.
 
 ## Running
 
@@ -31,7 +32,7 @@ At the moment, `ingress-controller-conformance` does not apply modifications to 
 
 You must manually install and setup you environment targeted by the `kubectl config current-context`:
 1. Apply the backing ingress-controller implementation. Samples are available under `examples/`.
-1. Apply all, or a subset, of the ingress and service resources found under `deployments`. Files under the deployments folder match implemented check names.
+1. Apply all, or a subset, of the ingress and service resources found under `deployments/`. Files under the `deployments` folder correspond to implemented check names.
 
 #### Context
 
@@ -45,7 +46,7 @@ The target Kubernetes cluster is running verion v1.14.6
 
 #### List
 
-List, in a human-readable form, all Ingress verifications
+Lists, in a human-readable form, all Ingress verifications
 ```
 $ ./ingress-controller-conformance list
 - Ingress with host rule should send traffic to the correct backend service (host-rules)

--- a/deployments/default-backend.yaml
+++ b/deployments/default-backend.yaml
@@ -3,12 +3,12 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: single-service
+  name: default-backend
   annotations:
     kubernetes.io/ingress.class: ambassador
 spec:
   backend:
-    serviceName: single-service
+    serviceName: default-backend
     servicePort: 80
 
 ---
@@ -16,10 +16,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: single-service
+  name: default-backend
 spec:
   selector:
-    app: single-service
+    app: default-backend
   ports:
     - name: http
       port: 80
@@ -30,18 +30,18 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: single-service
+  name: default-backend
 spec:
   replicas: 1
   strategy:
     type: RollingUpdate
   selector:
     matchLabels:
-      app: single-service
+      app: default-backend
   template:
     metadata:
       labels:
-        app: single-service
+        app: default-backend
     spec:
       containers:
         - name: ingress-conformance-echo
@@ -49,7 +49,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: TEST_ID
-              value: single-service
+              value: default-backend
           ports:
             - name: http-api
               containerPort: 3000

--- a/deployments/host-rules.yaml
+++ b/deployments/host-rules.yaml
@@ -8,12 +8,19 @@ metadata:
     kubernetes.io/ingress.class: ambassador
 spec:
   rules:
+    - host: "*.bar.com"
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: host-rules-wildcard
+              servicePort: 80
     - host: foo.bar.com
       http:
         paths:
           - path: /
             backend:
-              serviceName: host-rules
+              serviceName: host-rules-exact
               servicePort: 80
 
 ---
@@ -21,10 +28,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: host-rules
+  name: host-rules-exact
 spec:
   selector:
-    app: host-rules
+    app: host-rules-exact
   ports:
     - name: http
       port: 80
@@ -35,18 +42,18 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: host-rules
+  name: host-rules-exact
 spec:
   replicas: 1
   strategy:
     type: RollingUpdate
   selector:
     matchLabels:
-      app: host-rules
+      app: host-rules-exact
   template:
     metadata:
       labels:
-        app: host-rules
+        app: host-rules-exact
     spec:
       containers:
         - name: ingress-conformance-echo
@@ -54,7 +61,56 @@ spec:
           imagePullPolicy: Always
           env:
             - name: TEST_ID
-              value: host-rules
+              value: host-rules-exact
+          ports:
+            - name: http-api
+              containerPort: 3000
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 3
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: host-rules-wildcard
+spec:
+  selector:
+    app: host-rules-wildcard
+  ports:
+    - name: http
+      port: 80
+      targetPort: http-api
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: host-rules-wildcard
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: host-rules-wildcard
+  template:
+    metadata:
+      labels:
+        app: host-rules-wildcard
+    spec:
+      containers:
+        - name: ingress-conformance-echo
+          image: agervais/ingress-conformance-echo:latest
+          imagePullPolicy: Always
+          env:
+            - name: TEST_ID
+              value: host-rules-wildcard
           ports:
             - name: http-api
               containerPort: 3000

--- a/deployments/host-rules.yaml
+++ b/deployments/host-rules.yaml
@@ -8,13 +8,24 @@ metadata:
     kubernetes.io/ingress.class: ambassador
 spec:
   rules:
-    - host: "*.bar.com"
+    # Invalid hosts, validated by the api-server:
+    # - host: "*"
+    # - host: hosts with invalid labels are ignored
+    #
+    # "hosts with invalid labels are ignored": a DNS-1123 subdomain must consist
+    #  of lower case alphanumeric characters, '-' or '.', and must start and end
+    #  with an alphanumeric character (e.g. 'example.com', regex used for validation
+    #  is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
+    #
+
+    - host: "*.foo.com"
       http:
         paths:
           - path: /
             backend:
               serviceName: host-rules-wildcard
               servicePort: 80
+
     - host: foo.bar.com
       http:
         paths:

--- a/deployments/path-rules.yaml
+++ b/deployments/path-rules.yaml
@@ -18,6 +18,10 @@ spec:
             backend:
               serviceName: path-rules-bar
               servicePort: 80
+          - path: /
+            backend:
+              serviceName: path-rules-catchall
+              servicePort: 80
 
 ---
 
@@ -107,6 +111,55 @@ spec:
           env:
             - name: TEST_ID
               value: path-rules-bar
+          ports:
+            - name: http-api
+              containerPort: 3000
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 3
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: path-rules-catchall
+spec:
+  selector:
+    app: path-rules-catchall
+  ports:
+    - name: http
+      port: 80
+      targetPort: http-api
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: path-rules-catchall
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: path-rules-catchall
+  template:
+    metadata:
+      labels:
+        app: path-rules-catchall
+    spec:
+      containers:
+        - name: ingress-conformance-echo
+          image: agervais/ingress-conformance-echo:latest
+          imagePullPolicy: Always
+          env:
+            - name: TEST_ID
+              value: path-rules-catchall
           ports:
             - name: http-api
               containerPort: 3000

--- a/deployments/path-rules.yaml
+++ b/deployments/path-rules.yaml
@@ -8,16 +8,36 @@ metadata:
     kubernetes.io/ingress.class: ambassador
 spec:
   rules:
-    - http:
+    # Invalid paths, validated by the api-server:
+    # - path: routes/with/no-leading-slash/are-ignored
+    # - path: ../routes/with/relative-paths/are-ignored
+    #
+    # "must be an absolute path"
+    #
+
+    - host: "path-rules"
+      http:
         paths:
           - path: /foo
             backend:
               serviceName: path-rules-foo
               servicePort: 80
-          - path: /bar/
+
+          - path: /aaa/bbb/
             backend:
-              serviceName: path-rules-bar
+              serviceName: path-rules-aaa-bbb
               servicePort: 80
+
+          - path: /routes/with/consecutive//slashes///are-ignored
+            backend:
+              serviceName: void
+              servicePort: 80
+
+          - path: /routes with invalid characters are ignored!
+            backend:
+              serviceName: void
+              servicePort: 80
+
           - path: /
             backend:
               serviceName: path-rules-catchall
@@ -77,10 +97,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: path-rules-bar
+  name: path-rules-aaa-bbb
 spec:
   selector:
-    app: path-rules-bar
+    app: path-rules-aaa-bbb
   ports:
     - name: http
       port: 80
@@ -91,18 +111,18 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: path-rules-bar
+  name: path-rules-aaa-bbb
 spec:
   replicas: 1
   strategy:
     type: RollingUpdate
   selector:
     matchLabels:
-      app: path-rules-bar
+      app: path-rules-aaa-bbb
   template:
     metadata:
       labels:
-        app: path-rules-bar
+        app: path-rules-aaa-bbb
     spec:
       containers:
         - name: ingress-conformance-echo
@@ -110,7 +130,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: TEST_ID
-              value: path-rules-bar
+              value: path-rules-aaa-bbb
           ports:
             - name: http-api
               containerPort: 3000

--- a/internal/pkg/checks/assert.go
+++ b/internal/pkg/checks/assert.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Ingress conformance test harness machinery
+package checks
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// AssertionSet performs checks and accumulates assertion errors
+type AssertionSet []error
+
+// Assert actual and expected parameters are deeply equal
+func (a *AssertionSet) Equals(actual interface{}, expected interface{}, errorTemplate string) {
+	if errorTemplate == "" {
+		errorTemplate = "Expected '%s' but was '%s'"
+	}
+	if !reflect.DeepEqual(expected, actual) {
+		err := fmt.Errorf(errorTemplate, expected, actual)
+		*a = append(*a, err)
+	}
+}
+
+// Assert the actual headers contains the expected headers key
+func (a *AssertionSet) ContainsHeaders(actual map[string][]string, expected []string, errorTemplate string) {
+	if errorTemplate == "" {
+		errorTemplate = "Expected to contain '%s' but contained '%s'"
+	}
+	for _, expectedKey := range expected {
+		if actual[expectedKey] == nil {
+			err := fmt.Errorf(errorTemplate, expectedKey, actual)
+			*a = append(*a, err)
+		}
+	}
+}
+
+// Assert the actual headers contains exactly the expected headers key and no more
+func (a *AssertionSet) ContainsExactHeaders(actual map[string][]string, expected []string, errorTemplate string) {
+	a.ContainsHeaders(actual, expected, errorTemplate)
+	if errorTemplate == "" {
+		errorTemplate = "Expected to only contain '%s' but contained '%s'"
+	}
+	if len(actual) != len(expected) {
+		err := fmt.Errorf(errorTemplate, expected, actual)
+		*a = append(*a, err)
+	}
+}
+
+func (a *AssertionSet) Error() (err string) {
+	for i, e := range *a {
+		err += fmt.Sprintf("\t%d) Assertion failed: %s\n", i+1, e.Error())
+	}
+	return
+}

--- a/internal/pkg/checks/assert.go
+++ b/internal/pkg/checks/assert.go
@@ -25,10 +25,13 @@ import (
 // AssertionSet performs checks and accumulates assertion errors
 type AssertionSet []error
 
-// Assert actual and expected parameters are deeply equal
-func (a *AssertionSet) Equals(actual interface{}, expected interface{}, errorTemplate string) {
+// DeepEquals asserts actual and expected object parameters are deeply equal.
+//
+// The errorTemplate format specifier must include a first %v for the expected value
+// and a second %v for the actual value.
+func (a *AssertionSet) DeepEquals(actual interface{}, expected interface{}, errorTemplate string) {
 	if errorTemplate == "" {
-		errorTemplate = "Expected '%s' but was '%s'"
+		errorTemplate = "expected '%v' but was '%v'"
 	}
 	if !reflect.DeepEqual(expected, actual) {
 		err := fmt.Errorf(errorTemplate, expected, actual)
@@ -36,11 +39,9 @@ func (a *AssertionSet) Equals(actual interface{}, expected interface{}, errorTem
 	}
 }
 
-// Assert the actual headers contains the expected headers key
-func (a *AssertionSet) ContainsHeaders(actual map[string][]string, expected []string, errorTemplate string) {
-	if errorTemplate == "" {
-		errorTemplate = "Expected to contain '%s' but contained '%s'"
-	}
+// ContainsHeaders asserts the actual headers contains the expected header keys.
+func (a *AssertionSet) ContainsHeaders(actual map[string][]string, expected []string) {
+	errorTemplate := "expected headers to contain '%v' but contained '%v'"
 	for _, expectedKey := range expected {
 		if actual[expectedKey] == nil {
 			err := fmt.Errorf(errorTemplate, expectedKey, actual)
@@ -49,21 +50,21 @@ func (a *AssertionSet) ContainsHeaders(actual map[string][]string, expected []st
 	}
 }
 
-// Assert the actual headers contains exactly the expected headers key and no more
-func (a *AssertionSet) ContainsExactHeaders(actual map[string][]string, expected []string, errorTemplate string) {
-	a.ContainsHeaders(actual, expected, errorTemplate)
-	if errorTemplate == "" {
-		errorTemplate = "Expected to only contain '%s' but contained '%s'"
-	}
+// ContainsExactHeaders asserts the actual headers contains exactly the expected
+// header keys and nothing more.
+func (a *AssertionSet) ContainsExactHeaders(actual map[string][]string, expected []string) {
+	a.ContainsHeaders(actual, expected)
+	errorTemplate := "expected headers to only contain '%v' but contained '%v'"
 	if len(actual) != len(expected) {
 		err := fmt.Errorf(errorTemplate, expected, actual)
 		*a = append(*a, err)
 	}
 }
 
-func (a *AssertionSet) Error() (err string) {
+func (a *AssertionSet) Error() string {
+	var err string
 	for i, e := range *a {
 		err += fmt.Sprintf("\t%d) Assertion failed: %s\n", i+1, e.Error())
 	}
-	return
+	return err
 }

--- a/internal/pkg/checks/check.go
+++ b/internal/pkg/checks/check.go
@@ -19,6 +19,7 @@ package checks
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"reflect"
 	"time"
@@ -80,6 +81,8 @@ func captureRequest(location string, hostOverride string) (capReq CapturedReques
 
 	err = json.NewDecoder(resp.Body).Decode(&capReq)
 	if err != nil {
+		body, _ := ioutil.ReadAll(resp.Body)
+		err = fmt.Errorf("unexpected response (statuscode: %d, length: %d): %s", resp.StatusCode, len(body), body)
 		return
 	}
 

--- a/internal/pkg/checks/check.go
+++ b/internal/pkg/checks/check.go
@@ -45,10 +45,8 @@ type Check struct {
 
 // CapturedRequest contains the original HTTP request metadata as received
 // by the echoserver handling the test request.
-// The DownstreamServiceId field contains the TEST_ID environment variable
-// value of the downstream echoserver.
 type CapturedRequest struct {
-	DownstreamServiceId string `json:"testId"`
+	DownstreamServiceId string `json:"testId"` // DownstreamServiceId field contains the TEST_ID environment variable value of the downstream echoserver.
 	Path                string
 	Host                string
 	Method              string

--- a/internal/pkg/checks/check.go
+++ b/internal/pkg/checks/check.go
@@ -42,12 +42,12 @@ type Check struct {
 }
 
 type CapturedRequest struct {
-	TestId  string
-	Path    string
-	Host    string
-	Method  string
-	Proto   string
-	Headers map[string][]string
+	DownstreamServiceId string `json:"testId"`
+	Path                string
+	Host                string
+	Method              string
+	Proto               string
+	Headers             map[string][]string
 }
 
 type CapturedResponse struct {
@@ -95,9 +95,9 @@ func captureRequest(location string, hostOverride string) (capReq CapturedReques
 	return
 }
 
-type assertionSet []error
+type AssertionSet []error
 
-func (a *assertionSet) equals(actual interface{}, expected interface{}, errorTemplate string) {
+func (a *AssertionSet) Equals(actual interface{}, expected interface{}, errorTemplate string) {
 	if errorTemplate == "" {
 		errorTemplate = "Expected '%s' but was '%s'"
 	}
@@ -107,7 +107,7 @@ func (a *assertionSet) equals(actual interface{}, expected interface{}, errorTem
 	}
 }
 
-func (a *assertionSet) containsKeys(actual map[string][]string, expected []string, errorTemplate string) {
+func (a *AssertionSet) ContainsHeaders(actual map[string][]string, expected []string, errorTemplate string) {
 	if errorTemplate == "" {
 		errorTemplate = "Expected to contain '%s' but contained '%s'"
 	}
@@ -119,8 +119,8 @@ func (a *assertionSet) containsKeys(actual map[string][]string, expected []strin
 	}
 }
 
-func (a *assertionSet) containsOnlyKeys(actual map[string][]string, expected []string, errorTemplate string) {
-	a.containsKeys(actual, expected, errorTemplate)
+func (a *AssertionSet) ContainsExactHeaders(actual map[string][]string, expected []string, errorTemplate string) {
+	a.ContainsHeaders(actual, expected, errorTemplate)
 	if errorTemplate == "" {
 		errorTemplate = "Expected to only contain '%s' but contained '%s'"
 	}
@@ -130,7 +130,7 @@ func (a *assertionSet) containsOnlyKeys(actual map[string][]string, expected []s
 	}
 }
 
-func (a *assertionSet) Error() (err string) {
+func (a *AssertionSet) Error() (err string) {
 	for i, e := range *a {
 		err += fmt.Sprintf("\t%d) Assertion failed: %s\n", i+1, e.Error())
 	}

--- a/internal/pkg/checks/check.go
+++ b/internal/pkg/checks/check.go
@@ -153,7 +153,7 @@ var Checks = &Check{
 
 func (c Check) List() {
 	if c.Description != "" {
-		fmt.Printf("- %s (%s)\n", c.Description, c.Name)
+		fmt.Printf("- %s [%s]\n", c.Description, c.Name)
 	}
 	for _, check := range c.checks {
 		check.List()

--- a/internal/pkg/checks/defaultBackendCheck.go
+++ b/internal/pkg/checks/defaultBackendCheck.go
@@ -39,16 +39,16 @@ var singleServiceCheck = &Check{
 			return
 		}
 
-		a := new(assertionSet)
+		a := new(AssertionSet)
 		// Assert the request received from the downstream service
-		a.equals(req.TestId, "default-backend", "expected the downstream service would be '%s' but was '%s'")
-		a.equals(req.Method, "GET", "expected the originating request method would be '%s' but was '%s'")
-		a.equals(req.Proto, "HTTP/1.1", "expected the originating request protocol would be '%s' but was '%s'")
-		a.containsKeys(req.Headers, []string{"User-Agent"}, "expected the request headers would contain %s but contained %s")
+		a.Equals(req.DownstreamServiceId, "default-backend", "expected the downstream service would be '%s' but was '%s'")
+		a.Equals(req.Method, "GET", "expected the originating request method would be '%s' but was '%s'")
+		a.Equals(req.Proto, "HTTP/1.1", "expected the originating request protocol would be '%s' but was '%s'")
+		a.ContainsHeaders(req.Headers, []string{"User-Agent"}, "expected the request headers would contain %s but contained %s")
 		// Assert the downstream service response
-		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
-		a.equals(res.Proto, "HTTP/1.1", "expected the response protocol would be %s but was %s")
-		a.containsOnlyKeys(res.Headers, []string{"Content-Length", "Content-Type", "Date", "Server"}, "expected the response headers would contain %s but contained %s")
+		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.Equals(res.Proto, "HTTP/1.1", "expected the response protocol would be %s but was %s")
+		a.ContainsExactHeaders(res.Headers, []string{"Content-Length", "Content-Type", "Date", "Server"}, "expected the response headers would contain %s but contained %s")
 
 		if a.Error() == "" {
 			success = true

--- a/internal/pkg/checks/defaultBackendCheck.go
+++ b/internal/pkg/checks/defaultBackendCheck.go
@@ -26,10 +26,10 @@ func init() {
 }
 
 var singleServiceCheck = &Check{
-	Name:        "single-service",
-	Description: "Ingress with single-service should send traffic to the correct backend service",
+	Name:        "default-backend",
+	Description: "Ingress with a single default backend should send traffic to the correct backend service",
 	Run: func(check *Check, config Config) (success bool, err error) {
-		host, err := k8s.GetIngressHost("default", "single-service")
+		host, err := k8s.GetIngressHost("default", "default-backend")
 		if err != nil {
 			return
 		}
@@ -41,7 +41,7 @@ var singleServiceCheck = &Check{
 
 		a := new(assertionSet)
 		// Assert the request received from the downstream service
-		a.equals(req.TestId, "single-service", "expected the downstream service would be '%s' but was '%s'")
+		a.equals(req.TestId, "default-backend", "expected the downstream service would be '%s' but was '%s'")
 		a.equals(req.Method, "GET", "expected the originating request method would be '%s' but was '%s'")
 		a.equals(req.Proto, "HTTP/1.1", "expected the originating request protocol would be '%s' but was '%s'")
 		a.containsKeys(req.Headers, []string{"User-Agent"}, "expected the request headers would contain %s but contained %s")

--- a/internal/pkg/checks/defaultBackendCheck.go
+++ b/internal/pkg/checks/defaultBackendCheck.go
@@ -41,14 +41,14 @@ var singleServiceCheck = &Check{
 
 		a := &AssertionSet{}
 		// Assert the request received from the downstream service
-		a.Equals(req.DownstreamServiceId, "default-backend", "expected the downstream service would be '%s' but was '%s'")
-		a.Equals(req.Method, "GET", "expected the originating request method would be '%s' but was '%s'")
-		a.Equals(req.Proto, "HTTP/1.1", "expected the originating request protocol would be '%s' but was '%s'")
-		a.ContainsHeaders(req.Headers, []string{"User-Agent"}, "expected the request headers would contain %s but contained %s")
+		a.DeepEquals(req.DownstreamServiceId, "default-backend", "expected the downstream service would be '%s' but was '%s'")
+		a.DeepEquals(req.Method, "GET", "expected the originating request method would be '%s' but was '%s'")
+		a.DeepEquals(req.Proto, "HTTP/1.1", "expected the originating request protocol would be '%s' but was '%s'")
+		a.ContainsHeaders(req.Headers, []string{"User-Agent"})
 		// Assert the downstream service response
-		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
-		a.Equals(res.Proto, "HTTP/1.1", "expected the response protocol would be %s but was %s")
-		a.ContainsExactHeaders(res.Headers, []string{"Content-Length", "Content-Type", "Date", "Server"}, "expected the response headers would contain %s but contained %s")
+		a.DeepEquals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.DeepEquals(res.Proto, "HTTP/1.1", "expected the response protocol would be %s but was %s")
+		a.ContainsExactHeaders(res.Headers, []string{"Content-Length", "Content-Type", "Date", "Server"})
 
 		if a.Error() == "" {
 			return true, nil

--- a/internal/pkg/checks/hostRulesCheck.go
+++ b/internal/pkg/checks/hostRulesCheck.go
@@ -53,10 +53,10 @@ var hostRulesExactMatchCheck = &Check{
 
 		a := &AssertionSet{}
 		// Assert the request received from the downstream service
-		a.Equals(req.DownstreamServiceId, "host-rules-exact", "expected the downstream service would be '%s' but was '%s'")
-		a.Equals(req.Host, "foo.bar.com", "expected the request host would be '%s' but was '%s'")
+		a.DeepEquals(req.DownstreamServiceId, "host-rules-exact", "expected the downstream service would be '%s' but was '%s'")
+		a.DeepEquals(req.Host, "foo.bar.com", "expected the request host would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.DeepEquals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			return true, nil
@@ -78,10 +78,10 @@ var hostRulesWildcardSingleLabelCheck = &Check{
 
 		a := &AssertionSet{}
 		// Assert the request received from the downstream service
-		a.Equals(req.DownstreamServiceId, "host-rules-wildcard", "expected the downstream service would be '%s' but was '%s'")
-		a.Equals(req.Host, "wildcard.foo.com", "expected the request host would be '%s' but was '%s'")
+		a.DeepEquals(req.DownstreamServiceId, "host-rules-wildcard", "expected the downstream service would be '%s' but was '%s'")
+		a.DeepEquals(req.Host, "wildcard.foo.com", "expected the request host would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.DeepEquals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			return true, nil
@@ -103,10 +103,10 @@ var hostRulesWildcardMultipleLabelsCheck = &Check{
 
 		a := &AssertionSet{}
 		// Assert the request received from the downstream service
-		a.Equals(req.DownstreamServiceId, "default-backend", "expected the downstream service would be '%s' but was '%s'")
-		a.Equals(req.Host, "aaa.bbb.foo.com", "expected the request host would be '%s' but was '%s'")
+		a.DeepEquals(req.DownstreamServiceId, "default-backend", "expected the downstream service would be '%s' but was '%s'")
+		a.DeepEquals(req.Host, "aaa.bbb.foo.com", "expected the request host would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.DeepEquals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			return true, nil
@@ -128,10 +128,10 @@ var hostRulesWildcardNoLabelCheck = &Check{
 
 		a := &AssertionSet{}
 		// Assert the request received from the downstream service
-		a.Equals(req.DownstreamServiceId, "default-backend", "expected the downstream service would be '%s' but was '%s'")
-		a.Equals(req.Host, "foo.com", "expected the request host would be '%s' but was '%s'")
+		a.DeepEquals(req.DownstreamServiceId, "default-backend", "expected the downstream service would be '%s' but was '%s'")
+		a.DeepEquals(req.Host, "foo.com", "expected the request host would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.DeepEquals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			return true, nil

--- a/internal/pkg/checks/hostRulesCheck.go
+++ b/internal/pkg/checks/hostRulesCheck.go
@@ -32,26 +32,26 @@ func init() {
 var hostRulesHost string
 var hostRulesCheck = &Check{
 	Name: "host-rules",
-	Run: func(check *Check, config Config) (success bool, err error) {
+	Run: func(check *Check, config Config) (bool, error) {
+		var err error
 		hostRulesHost, err = k8s.GetIngressHost("default", "host-rules")
-		if err == nil {
-			success = true
+		if err != nil {
+			return false, err
 		}
-
-		return
+		return true, nil
 	},
 }
 
 var hostRulesExactMatchCheck = &Check{
 	Name:        "host-rules-exact-match",
 	Description: "Ingress with exact host rule should send traffic to the correct backend service",
-	Run: func(check *Check, config Config) (success bool, err error) {
-		req, res, err := captureRequest(fmt.Sprintf("http://%s", hostRulesHost), "foo.bar.com")
+	Run: func(check *Check, config Config) (bool, error) {
+		req, res, err := captureRoundTrip(fmt.Sprintf("http://%s", hostRulesHost), "foo.bar.com")
 		if err != nil {
-			return
+			return false, err
 		}
 
-		a := new(AssertionSet)
+		a := &AssertionSet{}
 		// Assert the request received from the downstream service
 		a.Equals(req.DownstreamServiceId, "host-rules-exact", "expected the downstream service would be '%s' but was '%s'")
 		a.Equals(req.Host, "foo.bar.com", "expected the request host would be '%s' but was '%s'")
@@ -59,24 +59,24 @@ var hostRulesExactMatchCheck = &Check{
 		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
-			success = true
+			return true, nil
 		} else {
 			fmt.Print(a)
 		}
-		return
+		return false, nil
 	},
 }
 
 var hostRulesWildcardSingleLabelCheck = &Check{
 	Name:        "host-rules-wildcard-single-label",
 	Description: "Ingress with wildcard host rule should match a single label",
-	Run: func(check *Check, config Config) (success bool, err error) {
-		req, res, err := captureRequest(fmt.Sprintf("http://%s", hostRulesHost), "wildcard.foo.com")
+	Run: func(check *Check, config Config) (bool, error) {
+		req, res, err := captureRoundTrip(fmt.Sprintf("http://%s", hostRulesHost), "wildcard.foo.com")
 		if err != nil {
-			return
+			return false, err
 		}
 
-		a := new(AssertionSet)
+		a := &AssertionSet{}
 		// Assert the request received from the downstream service
 		a.Equals(req.DownstreamServiceId, "host-rules-wildcard", "expected the downstream service would be '%s' but was '%s'")
 		a.Equals(req.Host, "wildcard.foo.com", "expected the request host would be '%s' but was '%s'")
@@ -84,24 +84,24 @@ var hostRulesWildcardSingleLabelCheck = &Check{
 		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
-			success = true
+			return true, nil
 		} else {
 			fmt.Print(a)
 		}
-		return
+		return false, nil
 	},
 }
 
 var hostRulesWildcardMultipleLabelsCheck = &Check{
 	Name:        "host-rules-wildcard-multiple-labels",
 	Description: "Ingress with wildcard host rule should only match a single label & fallback to default-backend",
-	Run: func(check *Check, config Config) (success bool, err error) {
-		req, res, err := captureRequest(fmt.Sprintf("http://%s", hostRulesHost), "aaa.bbb.foo.com")
+	Run: func(check *Check, config Config) (bool, error) {
+		req, res, err := captureRoundTrip(fmt.Sprintf("http://%s", hostRulesHost), "aaa.bbb.foo.com")
 		if err != nil {
-			return
+			return false, err
 		}
 
-		a := new(AssertionSet)
+		a := &AssertionSet{}
 		// Assert the request received from the downstream service
 		a.Equals(req.DownstreamServiceId, "default-backend", "expected the downstream service would be '%s' but was '%s'")
 		a.Equals(req.Host, "aaa.bbb.foo.com", "expected the request host would be '%s' but was '%s'")
@@ -109,24 +109,24 @@ var hostRulesWildcardMultipleLabelsCheck = &Check{
 		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
-			success = true
+			return true, nil
 		} else {
 			fmt.Print(a)
 		}
-		return
+		return false, nil
 	},
 }
 
 var hostRulesWildcardNoLabelCheck = &Check{
 	Name:        "host-rules-wildcard-no-label",
 	Description: "Ingress with wildcard host rule should match exactly one single label & fallback to default-backend",
-	Run: func(check *Check, config Config) (success bool, err error) {
-		req, res, err := captureRequest(fmt.Sprintf("http://%s", hostRulesHost), "foo.com")
+	Run: func(check *Check, config Config) (bool, error) {
+		req, res, err := captureRoundTrip(fmt.Sprintf("http://%s", hostRulesHost), "foo.com")
 		if err != nil {
-			return
+			return false, err
 		}
 
-		a := new(AssertionSet)
+		a := &AssertionSet{}
 		// Assert the request received from the downstream service
 		a.Equals(req.DownstreamServiceId, "default-backend", "expected the downstream service would be '%s' but was '%s'")
 		a.Equals(req.Host, "foo.com", "expected the request host would be '%s' but was '%s'")
@@ -134,10 +134,10 @@ var hostRulesWildcardNoLabelCheck = &Check{
 		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
-			success = true
+			return true, nil
 		} else {
 			fmt.Print(a)
 		}
-		return
+		return false, nil
 	},
 }

--- a/internal/pkg/checks/hostRulesCheck.go
+++ b/internal/pkg/checks/hostRulesCheck.go
@@ -23,9 +23,9 @@ import (
 
 func init() {
 	hostRulesCheck.AddCheck(hostRulesExactMatchCheck)
-	hostRulesCheck.AddCheck(hostRulesMatchingWildcardCheck)
-	hostRulesCheck.AddCheck(hostRulesTopLevelWildcardCheck)
-	hostRulesCheck.AddCheck(hostRulesMultilevelWildcardCheck)
+	hostRulesCheck.AddCheck(hostRulesWildcardSingleLabelCheck)
+	hostRulesCheck.AddCheck(hostRulesWildcardMultipleLabelsCheck)
+	hostRulesCheck.AddCheck(hostRulesWildcardNoLabelCheck)
 	Checks.AddCheck(hostRulesCheck)
 }
 
@@ -67,11 +67,11 @@ var hostRulesExactMatchCheck = &Check{
 	},
 }
 
-var hostRulesMatchingWildcardCheck = &Check{
-	Name:        "host-rules-wildcard",
-	Description: "Ingress with wildcard host rule should match single-level wildcard requests",
+var hostRulesWildcardSingleLabelCheck = &Check{
+	Name:        "host-rules-wildcard-single-label",
+	Description: "Ingress with wildcard host rule should match a single label",
 	Run: func(check *Check, config Config) (success bool, err error) {
-		req, res, err := captureRequest(fmt.Sprintf("http://%s", hostRulesHost), "wildcard.bar.com")
+		req, res, err := captureRequest(fmt.Sprintf("http://%s", hostRulesHost), "wildcard.foo.com")
 		if err != nil {
 			return
 		}
@@ -79,7 +79,7 @@ var hostRulesMatchingWildcardCheck = &Check{
 		a := new(assertionSet)
 		// Assert the request received from the downstream service
 		a.equals(req.TestId, "host-rules-wildcard", "expected the downstream service would be '%s' but was '%s'")
-		a.equals(req.Host, "wildcard.bar.com", "expected the request host would be '%s' but was '%s'")
+		a.equals(req.Host, "wildcard.foo.com", "expected the request host would be '%s' but was '%s'")
 		// Assert the downstream service response
 		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
@@ -92,19 +92,19 @@ var hostRulesMatchingWildcardCheck = &Check{
 	},
 }
 
-var hostRulesTopLevelWildcardCheck = &Check{
-	Name:        "host-rules-toplevel-wildcard",
-	Description: "Ingress with wildcard host rule should not match top level requests & fallback to single-service",
+var hostRulesWildcardMultipleLabelsCheck = &Check{
+	Name:        "host-rules-wildcard-multiple-labels",
+	Description: "Ingress with wildcard host rule should only match a single label & fallback to default-backend",
 	Run: func(check *Check, config Config) (success bool, err error) {
-		req, res, err := captureRequest(fmt.Sprintf("http://%s", hostRulesHost), "bar.com")
+		req, res, err := captureRequest(fmt.Sprintf("http://%s", hostRulesHost), "aaa.bbb.foo.com")
 		if err != nil {
 			return
 		}
 
 		a := new(assertionSet)
 		// Assert the request received from the downstream service
-		a.equals(req.TestId, "single-service", "expected the downstream service would be '%s' but was '%s'")
-		a.equals(req.Host, "bar.com", "expected the request host would be '%s' but was '%s'")
+		a.equals(req.TestId, "default-backend", "expected the downstream service would be '%s' but was '%s'")
+		a.equals(req.Host, "aaa.bbb.foo.com", "expected the request host would be '%s' but was '%s'")
 		// Assert the downstream service response
 		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
@@ -117,19 +117,19 @@ var hostRulesTopLevelWildcardCheck = &Check{
 	},
 }
 
-var hostRulesMultilevelWildcardCheck = &Check{
-	Name:        "host-rules-multilevel-wildcard",
-	Description: "Ingress with wildcard host rule should not match multi-level wildcard requests & fallback to single-service",
+var hostRulesWildcardNoLabelCheck = &Check{
+	Name:        "host-rules-wildcard-no-label",
+	Description: "Ingress with wildcard host rule should match exactly one single label & fallback to default-backend",
 	Run: func(check *Check, config Config) (success bool, err error) {
-		req, res, err := captureRequest(fmt.Sprintf("http://%s", hostRulesHost), "wildcard.foo.bar.com")
+		req, res, err := captureRequest(fmt.Sprintf("http://%s", hostRulesHost), "foo.com")
 		if err != nil {
 			return
 		}
 
 		a := new(assertionSet)
 		// Assert the request received from the downstream service
-		a.equals(req.TestId, "single-service", "expected the downstream service would be '%s' but was '%s'")
-		a.equals(req.Host, "wildcard.foo.bar.com", "expected the request host would be '%s' but was '%s'")
+		a.equals(req.TestId, "default-backend", "expected the downstream service would be '%s' but was '%s'")
+		a.equals(req.Host, "foo.com", "expected the request host would be '%s' but was '%s'")
 		// Assert the downstream service response
 		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 

--- a/internal/pkg/checks/hostRulesCheck.go
+++ b/internal/pkg/checks/hostRulesCheck.go
@@ -51,12 +51,12 @@ var hostRulesExactMatchCheck = &Check{
 			return
 		}
 
-		a := new(assertionSet)
+		a := new(AssertionSet)
 		// Assert the request received from the downstream service
-		a.equals(req.TestId, "host-rules-exact", "expected the downstream service would be '%s' but was '%s'")
-		a.equals(req.Host, "foo.bar.com", "expected the request host would be '%s' but was '%s'")
+		a.Equals(req.DownstreamServiceId, "host-rules-exact", "expected the downstream service would be '%s' but was '%s'")
+		a.Equals(req.Host, "foo.bar.com", "expected the request host would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			success = true
@@ -76,12 +76,12 @@ var hostRulesWildcardSingleLabelCheck = &Check{
 			return
 		}
 
-		a := new(assertionSet)
+		a := new(AssertionSet)
 		// Assert the request received from the downstream service
-		a.equals(req.TestId, "host-rules-wildcard", "expected the downstream service would be '%s' but was '%s'")
-		a.equals(req.Host, "wildcard.foo.com", "expected the request host would be '%s' but was '%s'")
+		a.Equals(req.DownstreamServiceId, "host-rules-wildcard", "expected the downstream service would be '%s' but was '%s'")
+		a.Equals(req.Host, "wildcard.foo.com", "expected the request host would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			success = true
@@ -101,12 +101,12 @@ var hostRulesWildcardMultipleLabelsCheck = &Check{
 			return
 		}
 
-		a := new(assertionSet)
+		a := new(AssertionSet)
 		// Assert the request received from the downstream service
-		a.equals(req.TestId, "default-backend", "expected the downstream service would be '%s' but was '%s'")
-		a.equals(req.Host, "aaa.bbb.foo.com", "expected the request host would be '%s' but was '%s'")
+		a.Equals(req.DownstreamServiceId, "default-backend", "expected the downstream service would be '%s' but was '%s'")
+		a.Equals(req.Host, "aaa.bbb.foo.com", "expected the request host would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			success = true
@@ -126,12 +126,12 @@ var hostRulesWildcardNoLabelCheck = &Check{
 			return
 		}
 
-		a := new(assertionSet)
+		a := new(AssertionSet)
 		// Assert the request received from the downstream service
-		a.equals(req.TestId, "default-backend", "expected the downstream service would be '%s' but was '%s'")
-		a.equals(req.Host, "foo.com", "expected the request host would be '%s' but was '%s'")
+		a.Equals(req.DownstreamServiceId, "default-backend", "expected the downstream service would be '%s' but was '%s'")
+		a.Equals(req.Host, "foo.com", "expected the request host would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			success = true

--- a/internal/pkg/checks/pathRulesCheck.go
+++ b/internal/pkg/checks/pathRulesCheck.go
@@ -36,7 +36,6 @@ func init() {
 	pathRulesPrefixCheck.AddCheck(pathRulesPrefixAaaBbbCheck)
 	pathRulesPrefixCheck.AddCheck(pathRulesPrefixAaaBbbSlashCheck)
 	pathRulesPrefixCheck.AddCheck(pathRulesPrefixAaaBbbCccCheck)
-	pathRulesPrefixCheck.AddCheck(pathRulesPrefixAaaBbCheck)
 	pathRulesPrefixCheck.AddCheck(pathRulesPrefixAaaBbbcccCheck)
 	pathRulesPrefixCheck.AddCheck(pathRulesPrefixConsecutiveSlashesCheck)
 	pathRulesPrefixCheck.AddCheck(pathRulesPrefixConsecutiveSlashesNormalizedCheck)
@@ -76,12 +75,12 @@ var pathRulesPrefixAllPathsCheck = &Check{
 			return
 		}
 
-		a := new(assertionSet)
+		a := new(AssertionSet)
 		// Assert the request received from the downstream service
-		a.equals(req.TestId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
-		a.equals(req.Path, "/", "expected the request path would be '%s' but was '%s'")
+		a.Equals(req.DownstreamServiceId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
+		a.Equals(req.Path, "/", "expected the request path would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			success = true
@@ -101,12 +100,12 @@ var pathRulesPrefixFooCheck = &Check{
 			return
 		}
 
-		a := new(assertionSet)
+		a := new(AssertionSet)
 		// Assert the request received from the downstream service
-		a.equals(req.TestId, "path-rules-foo", "expected the downstream service would be '%s' but was '%s'")
-		a.equals(req.Path, "/foo", "expected the request path would be '%s' but was '%s'")
+		a.Equals(req.DownstreamServiceId, "path-rules-foo", "expected the downstream service would be '%s' but was '%s'")
+		a.Equals(req.Path, "/foo", "expected the request path would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			success = true
@@ -126,12 +125,12 @@ var pathRulesPrefixFooSlashCheck = &Check{
 			return
 		}
 
-		a := new(assertionSet)
+		a := new(AssertionSet)
 		// Assert the request received from the downstream service
-		a.equals(req.TestId, "path-rules-foo", "expected the downstream service would be '%s' but was '%s'")
-		a.equals(req.Path, "/foo/", "expected the request path would be '%s' but was '%s'")
+		a.Equals(req.DownstreamServiceId, "path-rules-foo", "expected the downstream service would be '%s' but was '%s'")
+		a.Equals(req.Path, "/foo/", "expected the request path would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			success = true
@@ -151,12 +150,12 @@ var pathRulesPrefixFoCheck = &Check{
 			return
 		}
 
-		a := new(assertionSet)
+		a := new(AssertionSet)
 		// Assert the request received from the downstream service
-		a.equals(req.TestId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
-		a.equals(req.Path, "/fo", "expected the request path would be '%s' but was '%s'")
+		a.Equals(req.DownstreamServiceId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
+		a.Equals(req.Path, "/fo", "expected the request path would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			success = true
@@ -176,12 +175,12 @@ var pathRulesPrefixAaaBbbCheck = &Check{
 			return
 		}
 
-		a := new(assertionSet)
+		a := new(AssertionSet)
 		// Assert the request received from the downstream service
-		a.equals(req.TestId, "path-rules-aaa-bbb", "expected the downstream service would be '%s' but was '%s'")
-		a.equals(req.Path, "/aaa/bbb", "expected the request path would be '%s' but was '%s'")
+		a.Equals(req.DownstreamServiceId, "path-rules-aaa-bbb", "expected the downstream service would be '%s' but was '%s'")
+		a.Equals(req.Path, "/aaa/bbb", "expected the request path would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			success = true
@@ -201,12 +200,12 @@ var pathRulesPrefixAaaBbbSlashCheck = &Check{
 			return
 		}
 
-		a := new(assertionSet)
+		a := new(AssertionSet)
 		// Assert the request received from the downstream service
-		a.equals(req.TestId, "path-rules-aaa-bbb", "expected the downstream service would be '%s' but was '%s'")
-		a.equals(req.Path, "/aaa/bbb/", "expected the request path would be '%s' but was '%s'")
+		a.Equals(req.DownstreamServiceId, "path-rules-aaa-bbb", "expected the downstream service would be '%s' but was '%s'")
+		a.Equals(req.Path, "/aaa/bbb/", "expected the request path would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			success = true
@@ -226,37 +225,12 @@ var pathRulesPrefixAaaBbbCccCheck = &Check{
 			return
 		}
 
-		a := new(assertionSet)
+		a := new(AssertionSet)
 		// Assert the request received from the downstream service
-		a.equals(req.TestId, "path-rules-aaa-bbb", "expected the downstream service would be '%s' but was '%s'")
-		a.equals(req.Path, "/aaa/bbb/ccc", "expected the request path would be '%s' but was '%s'")
+		a.Equals(req.DownstreamServiceId, "path-rules-aaa-bbb", "expected the downstream service would be '%s' but was '%s'")
+		a.Equals(req.Path, "/aaa/bbb/ccc", "expected the request path would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
-
-		if a.Error() == "" {
-			success = true
-		} else {
-			fmt.Print(a)
-		}
-		return
-	},
-}
-
-var pathRulesPrefixAaaBbCheck = &Check{
-	Name:        "path-rules-prefix-aaa-bb",
-	Description: "Ingress with prefix path rule with a trailing slash should not match partial paths (/aaa/bbb/ does not match /aaa/bb)",
-	Run: func(check *Check, config Config) (success bool, err error) {
-		req, res, err := captureRequest(fmt.Sprintf("http://%s/aaa/bb", pathRulesHost), "path-rules")
-		if err != nil {
-			return
-		}
-
-		a := new(assertionSet)
-		// Assert the request received from the downstream service
-		a.equals(req.TestId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
-		a.equals(req.Path, "/aaa/bb", "expected the request path would be '%s' but was '%s'")
-		// Assert the downstream service response
-		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			success = true
@@ -276,12 +250,12 @@ var pathRulesPrefixAaaBbbcccCheck = &Check{
 			return
 		}
 
-		a := new(assertionSet)
+		a := new(AssertionSet)
 		// Assert the request received from the downstream service
-		a.equals(req.TestId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
-		a.equals(req.Path, "/aaa/bbbccc", "expected the request path would be '%s' but was '%s'")
+		a.Equals(req.DownstreamServiceId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
+		a.Equals(req.Path, "/aaa/bbbccc", "expected the request path would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			success = true
@@ -301,12 +275,12 @@ var pathRulesPrefixConsecutiveSlashesCheck = &Check{
 			return
 		}
 
-		a := new(assertionSet)
+		a := new(AssertionSet)
 		// Assert the request received from the downstream service
-		a.equals(req.TestId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
-		a.equals(req.Path, "/routes/with/consecutive//slashes///are-ignored", "expected the request path would be '%s' but was '%s'")
+		a.Equals(req.DownstreamServiceId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
+		a.Equals(req.Path, "/routes/with/consecutive//slashes///are-ignored", "expected the request path would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			success = true
@@ -326,12 +300,12 @@ var pathRulesPrefixConsecutiveSlashesNormalizedCheck = &Check{
 			return
 		}
 
-		a := new(assertionSet)
+		a := new(AssertionSet)
 		// Assert the request received from the downstream service
-		a.equals(req.TestId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
-		a.equals(req.Path, "/routes/with/consecutive/slashes/are-ignored", "expected the request path would be '%s' but was '%s'")
+		a.Equals(req.DownstreamServiceId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
+		a.Equals(req.Path, "/routes/with/consecutive/slashes/are-ignored", "expected the request path would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			success = true
@@ -351,12 +325,12 @@ var pathRulesPrefixInvalidCharactersCheck = &Check{
 			return
 		}
 
-		a := new(assertionSet)
+		a := new(AssertionSet)
 		// Assert the request received from the downstream service
-		a.equals(req.TestId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
-		a.equals(req.Path, "/routes%20with%20invalid%20characters%20are%20ignored%21", "expected the request path would be '%s' but was '%s'")
+		a.Equals(req.DownstreamServiceId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
+		a.Equals(req.Path, "/routes%20with%20invalid%20characters%20are%20ignored%21", "expected the request path would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			success = true

--- a/internal/pkg/checks/pathRulesCheck.go
+++ b/internal/pkg/checks/pathRulesCheck.go
@@ -22,14 +22,27 @@ import (
 )
 
 func init() {
-	pathRulesCheck.AddCheck(prefixPathRulesFooCheck)
-	pathRulesCheck.AddCheck(prefixPathRulesFooTrailingSlashCheck)
-	pathRulesCheck.AddCheck(prefixPathRulesFooSubpathCheck)
-	pathRulesCheck.AddCheck(prefixPathRulesFooNomatchPrefixCheck)
-	pathRulesCheck.AddCheck(prefixPathRulesBarCheck)
-	pathRulesCheck.AddCheck(prefixPathRulesBarTrailingSlashCheck)
-	pathRulesCheck.AddCheck(prefixPathRulesBarSubpathCheck)
-	pathRulesCheck.AddCheck(prefixPathRulesBarNomatchPrefixCheck)
+	/*
+			TODO: There are currently no 'exact' path types validations since it is unsupported in v1beta1
+		          For now, we validate only the 'prefix' path types, which is closer to the v1beta1 'prefix'
+		          path type assumption.
+	*/
+	pathRulesCheck.AddCheck(pathRulesExactCheck)
+
+	pathRulesPrefixCheck.AddCheck(pathRulesPrefixAllPathsCheck)
+	pathRulesPrefixCheck.AddCheck(pathRulesPrefixFooCheck)
+	pathRulesPrefixCheck.AddCheck(pathRulesPrefixFooSlashCheck)
+	pathRulesPrefixCheck.AddCheck(pathRulesPrefixFoCheck)
+	pathRulesPrefixCheck.AddCheck(pathRulesPrefixAaaBbbCheck)
+	pathRulesPrefixCheck.AddCheck(pathRulesPrefixAaaBbbSlashCheck)
+	pathRulesPrefixCheck.AddCheck(pathRulesPrefixAaaBbbCccCheck)
+	pathRulesPrefixCheck.AddCheck(pathRulesPrefixAaaBbCheck)
+	pathRulesPrefixCheck.AddCheck(pathRulesPrefixAaaBbbcccCheck)
+	pathRulesPrefixCheck.AddCheck(pathRulesPrefixConsecutiveSlashesCheck)
+	pathRulesPrefixCheck.AddCheck(pathRulesPrefixConsecutiveSlashesNormalizedCheck)
+	pathRulesPrefixCheck.AddCheck(pathRulesPrefixInvalidCharactersCheck)
+	pathRulesCheck.AddCheck(pathRulesPrefixCheck)
+
 	Checks.AddCheck(pathRulesCheck)
 }
 
@@ -46,11 +59,44 @@ var pathRulesCheck = &Check{
 	},
 }
 
-var prefixPathRulesFooCheck = &Check{
-	Name:        "prefix-path-rules-foo",
-	Description: "Ingress with prefix path rule without a trailing slash should send traffic to the correct backend service, and preserve the original request path",
+var pathRulesExactCheck = &Check{
+	Name: "path-rules-exact",
+}
+
+var pathRulesPrefixCheck = &Check{
+	Name: "path-rules-prefix",
+}
+
+var pathRulesPrefixAllPathsCheck = &Check{
+	Name:        "path-rules-prefix-all-paths",
+	Description: "Ingress with prefix path rule '/' should match all paths",
 	Run: func(check *Check, config Config) (success bool, err error) {
-		req, res, err := captureRequest(fmt.Sprintf("http://%s/foo", pathRulesHost), "")
+		req, res, err := captureRequest(fmt.Sprintf("http://%s", pathRulesHost), "path-rules")
+		if err != nil {
+			return
+		}
+
+		a := new(assertionSet)
+		// Assert the request received from the downstream service
+		a.equals(req.TestId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
+		a.equals(req.Path, "/", "expected the request path would be '%s' but was '%s'")
+		// Assert the downstream service response
+		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+
+		if a.Error() == "" {
+			success = true
+		} else {
+			fmt.Print(a)
+		}
+		return
+	},
+}
+
+var pathRulesPrefixFooCheck = &Check{
+	Name:        "path-rules-prefix-foo",
+	Description: "Ingress with prefix path rule without a trailing slash should send traffic to the correct backend service, and preserve the original request path (/foo matches /foo)",
+	Run: func(check *Check, config Config) (success bool, err error) {
+		req, res, err := captureRequest(fmt.Sprintf("http://%s/foo", pathRulesHost), "path-rules")
 		if err != nil {
 			return
 		}
@@ -71,11 +117,11 @@ var prefixPathRulesFooCheck = &Check{
 	},
 }
 
-var prefixPathRulesFooTrailingSlashCheck = &Check{
-	Name:        "prefix-path-rules-foo-trailing",
-	Description: "Ingress with prefix path rule without a trailing slash should send traffic to the correct backend service, and preserve the original request including sub-paths",
+var pathRulesPrefixFooSlashCheck = &Check{
+	Name:        "path-rules-prefix-foo-slash",
+	Description: "Ingress with prefix path rule without a trailing slash should send traffic to the correct backend service, and preserve the original request path (/foo matches /foo/)",
 	Run: func(check *Check, config Config) (success bool, err error) {
-		req, res, err := captureRequest(fmt.Sprintf("http://%s/foo/", pathRulesHost), "")
+		req, res, err := captureRequest(fmt.Sprintf("http://%s/foo/", pathRulesHost), "path-rules")
 		if err != nil {
 			return
 		}
@@ -96,36 +142,11 @@ var prefixPathRulesFooTrailingSlashCheck = &Check{
 	},
 }
 
-var prefixPathRulesFooSubpathCheck = &Check{
-	Name:        "prefix-path-rules-foo-subpath",
-	Description: "Ingress with prefix path rule without a trailing slash should send traffic to the correct backend service, and preserve the original request",
+var pathRulesPrefixFoCheck = &Check{
+	Name:        "path-rules-prefix-fo",
+	Description: "Ingress with prefix path rule without a trailing slash should not match partial paths (/foo does not match /fo)",
 	Run: func(check *Check, config Config) (success bool, err error) {
-		req, res, err := captureRequest(fmt.Sprintf("http://%s/foo/bar", pathRulesHost), "")
-		if err != nil {
-			return
-		}
-
-		a := new(assertionSet)
-		// Assert the request received from the downstream service
-		a.equals(req.TestId, "path-rules-foo", "expected the downstream service would be '%s' but was '%s'")
-		a.equals(req.Path, "/foo/bar", "expected the request path would be '%s' but was '%s'")
-		// Assert the downstream service response
-		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
-
-		if a.Error() == "" {
-			success = true
-		} else {
-			fmt.Print(a)
-		}
-		return
-	},
-}
-
-var prefixPathRulesFooNomatchPrefixCheck = &Check{
-	Name:        "prefix-path-rules-foo-nomatch",
-	Description: "Ingress with prefix path rule with a trailing slash should not match on a partial path and fallback to catch-all",
-	Run: func(check *Check, config Config) (success bool, err error) {
-		req, res, err := captureRequest(fmt.Sprintf("http://%s/foobar", pathRulesHost), "")
+		req, res, err := captureRequest(fmt.Sprintf("http://%s/fo", pathRulesHost), "path-rules")
 		if err != nil {
 			return
 		}
@@ -133,7 +154,7 @@ var prefixPathRulesFooNomatchPrefixCheck = &Check{
 		a := new(assertionSet)
 		// Assert the request received from the downstream service
 		a.equals(req.TestId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
-		a.equals(req.Path, "/foobar", "expected the request path would be '%s' but was '%s'")
+		a.equals(req.Path, "/fo", "expected the request path would be '%s' but was '%s'")
 		// Assert the downstream service response
 		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
@@ -146,19 +167,19 @@ var prefixPathRulesFooNomatchPrefixCheck = &Check{
 	},
 }
 
-var prefixPathRulesBarCheck = &Check{
-	Name:        "prefix-path-rules-bar",
-	Description: "Ingress with prefix path rule with a trailing slash should send traffic to the correct backend service, and preserve the original request path",
+var pathRulesPrefixAaaBbbCheck = &Check{
+	Name:        "path-rules-prefix-aaa-bbb",
+	Description: "Ingress with prefix path rule with a trailing slash should send traffic to the correct backend service, and preserve the original request path (/aaa/bbb/ matches /aaa/bbb)",
 	Run: func(check *Check, config Config) (success bool, err error) {
-		req, res, err := captureRequest(fmt.Sprintf("http://%s/bar/", pathRulesHost), "")
+		req, res, err := captureRequest(fmt.Sprintf("http://%s/aaa/bbb", pathRulesHost), "path-rules")
 		if err != nil {
 			return
 		}
 
 		a := new(assertionSet)
 		// Assert the request received from the downstream service
-		a.equals(req.TestId, "path-rules-bar", "expected the downstream service would be '%s' but was '%s'")
-		a.equals(req.Path, "/bar/", "expected the request path would be '%s' but was '%s'")
+		a.equals(req.TestId, "path-rules-aaa-bbb", "expected the downstream service would be '%s' but was '%s'")
+		a.equals(req.Path, "/aaa/bbb", "expected the request path would be '%s' but was '%s'")
 		// Assert the downstream service response
 		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
@@ -171,19 +192,19 @@ var prefixPathRulesBarCheck = &Check{
 	},
 }
 
-var prefixPathRulesBarTrailingSlashCheck = &Check{
-	Name:        "prefix-path-rules-bar-trailing-slash-ignored",
-	Description: "Ingress with prefix path rule with a trailing slash is ignored and should send traffic to the correct backend service, and preserve the original request path",
+var pathRulesPrefixAaaBbbSlashCheck = &Check{
+	Name:        "path-rules-prefix-aaa-bbb-slash",
+	Description: "Ingress with prefix path rule with a trailing slash should send traffic to the correct backend service, and preserve the original request path (/aaa/bbb/ matches /aaa/bbb/)",
 	Run: func(check *Check, config Config) (success bool, err error) {
-		req, res, err := captureRequest(fmt.Sprintf("http://%s/bar", pathRulesHost), "")
+		req, res, err := captureRequest(fmt.Sprintf("http://%s/aaa/bbb/", pathRulesHost), "path-rules")
 		if err != nil {
 			return
 		}
 
 		a := new(assertionSet)
 		// Assert the request received from the downstream service
-		a.equals(req.TestId, "path-rules-bar", "expected the downstream service would be '%s' but was '%s'")
-		a.equals(req.Path, "/bar/", "expected the request path would be '%s' but was '%s'")
+		a.equals(req.TestId, "path-rules-aaa-bbb", "expected the downstream service would be '%s' but was '%s'")
+		a.equals(req.Path, "/aaa/bbb/", "expected the request path would be '%s' but was '%s'")
 		// Assert the downstream service response
 		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
@@ -196,19 +217,19 @@ var prefixPathRulesBarTrailingSlashCheck = &Check{
 	},
 }
 
-var prefixPathRulesBarSubpathCheck = &Check{
-	Name:        "prefix-path-rules-bar-subpath",
-	Description: "Ingress with prefix path rule with a trailing slash should send traffic to the correct backend service, and preserve the original request including sub-paths and double '/'",
+var pathRulesPrefixAaaBbbCccCheck = &Check{
+	Name:        "path-rules-prefix-aaa-bbb-ccc",
+	Description: "Ingress with prefix path rule with a trailing slash should match subpath, send traffic to the correct backend service, and preserve the original request path (/aaa/bbb/ matches /aaa/bbb/ccc)",
 	Run: func(check *Check, config Config) (success bool, err error) {
-		req, res, err := captureRequest(fmt.Sprintf("http://%s/bar//bershop", pathRulesHost), "")
+		req, res, err := captureRequest(fmt.Sprintf("http://%s/aaa/bbb/ccc", pathRulesHost), "path-rules")
 		if err != nil {
 			return
 		}
 
 		a := new(assertionSet)
 		// Assert the request received from the downstream service
-		a.equals(req.TestId, "path-rules-bar", "expected the downstream service would be '%s' but was '%s'")
-		a.equals(req.Path, "/bar//bershop", "expected the request path would be '%s' but was '%s'")
+		a.equals(req.TestId, "path-rules-aaa-bbb", "expected the downstream service would be '%s' but was '%s'")
+		a.equals(req.Path, "/aaa/bbb/ccc", "expected the request path would be '%s' but was '%s'")
 		// Assert the downstream service response
 		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
@@ -221,11 +242,11 @@ var prefixPathRulesBarSubpathCheck = &Check{
 	},
 }
 
-var prefixPathRulesBarNomatchPrefixCheck = &Check{
-	Name:        "prefix-path-rules-bar-nomatch",
-	Description: "Ingress with prefix path rule with a trailing slash should not match on a partial path and fallback to catch-all",
+var pathRulesPrefixAaaBbCheck = &Check{
+	Name:        "path-rules-prefix-aaa-bb",
+	Description: "Ingress with prefix path rule with a trailing slash should not match partial paths (/aaa/bbb/ does not match /aaa/bb)",
 	Run: func(check *Check, config Config) (success bool, err error) {
-		req, res, err := captureRequest(fmt.Sprintf("http://%s/barbershop", pathRulesHost), "")
+		req, res, err := captureRequest(fmt.Sprintf("http://%s/aaa/bb", pathRulesHost), "path-rules")
 		if err != nil {
 			return
 		}
@@ -233,7 +254,107 @@ var prefixPathRulesBarNomatchPrefixCheck = &Check{
 		a := new(assertionSet)
 		// Assert the request received from the downstream service
 		a.equals(req.TestId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
-		a.equals(req.Path, "/barbershop", "expected the request path would be '%s' but was '%s'")
+		a.equals(req.Path, "/aaa/bb", "expected the request path would be '%s' but was '%s'")
+		// Assert the downstream service response
+		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+
+		if a.Error() == "" {
+			success = true
+		} else {
+			fmt.Print(a)
+		}
+		return
+	},
+}
+
+var pathRulesPrefixAaaBbbcccCheck = &Check{
+	Name:        "path-rules-prefix-aaa-bbbccc",
+	Description: "Ingress with prefix path rule with a trailing slash should not match string prefix (/aaa/bbb/ does not match /aaa/bbbccc)",
+	Run: func(check *Check, config Config) (success bool, err error) {
+		req, res, err := captureRequest(fmt.Sprintf("http://%s/aaa/bbbccc", pathRulesHost), "path-rules")
+		if err != nil {
+			return
+		}
+
+		a := new(assertionSet)
+		// Assert the request received from the downstream service
+		a.equals(req.TestId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
+		a.equals(req.Path, "/aaa/bbbccc", "expected the request path would be '%s' but was '%s'")
+		// Assert the downstream service response
+		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+
+		if a.Error() == "" {
+			success = true
+		} else {
+			fmt.Print(a)
+		}
+		return
+	},
+}
+
+var pathRulesPrefixConsecutiveSlashesCheck = &Check{
+	Name:        "path-rules-prefix-consecutive-slashes",
+	Description: "Ingress with prefix path rule with consecutive slashes are ignored",
+	Run: func(check *Check, config Config) (success bool, err error) {
+		req, res, err := captureRequest(fmt.Sprintf("http://%s/routes/with/consecutive//slashes///are-ignored", pathRulesHost), "path-rules")
+		if err != nil {
+			return
+		}
+
+		a := new(assertionSet)
+		// Assert the request received from the downstream service
+		a.equals(req.TestId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
+		a.equals(req.Path, "/routes/with/consecutive//slashes///are-ignored", "expected the request path would be '%s' but was '%s'")
+		// Assert the downstream service response
+		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+
+		if a.Error() == "" {
+			success = true
+		} else {
+			fmt.Print(a)
+		}
+		return
+	},
+}
+
+var pathRulesPrefixConsecutiveSlashesNormalizedCheck = &Check{
+	Name:        "path-rules-prefix-consecutive-slashes-normalized",
+	Description: "Ingress with prefix path rule with consecutive slashes are ignored",
+	Run: func(check *Check, config Config) (success bool, err error) {
+		req, res, err := captureRequest(fmt.Sprintf("http://%s/routes/with/consecutive/slashes/are-ignored", pathRulesHost), "path-rules")
+		if err != nil {
+			return
+		}
+
+		a := new(assertionSet)
+		// Assert the request received from the downstream service
+		a.equals(req.TestId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
+		a.equals(req.Path, "/routes/with/consecutive/slashes/are-ignored", "expected the request path would be '%s' but was '%s'")
+		// Assert the downstream service response
+		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+
+		if a.Error() == "" {
+			success = true
+		} else {
+			fmt.Print(a)
+		}
+		return
+	},
+}
+
+var pathRulesPrefixInvalidCharactersCheck = &Check{
+	Name:        "path-rules-prefix-invalid-characters",
+	Description: "Ingress with prefix path rule with consecutive slashes are ignored",
+	Run: func(check *Check, config Config) (success bool, err error) {
+		req, res, err := captureRequest(fmt.Sprintf("http://%s/routes with invalid characters are ignored!", pathRulesHost), "path-rules")
+		if err != nil {
+			return
+		}
+
+		a := new(assertionSet)
+		// Assert the request received from the downstream service
+		a.equals(req.TestId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
+		a.equals(req.Path, "/routes%20with%20invalid%20characters%20are%20ignored%21", "expected the request path would be '%s' but was '%s'")
 		// Assert the downstream service response
 		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 

--- a/internal/pkg/checks/pathRulesCheck.go
+++ b/internal/pkg/checks/pathRulesCheck.go
@@ -48,20 +48,22 @@ func init() {
 var pathRulesHost string
 var pathRulesCheck = &Check{
 	Name: "path-rules",
-	Run: func(check *Check, config Config) (success bool, err error) {
+	Run: func(check *Check, config Config) (bool, error) {
+		var err error
 		pathRulesHost, err = k8s.GetIngressHost("default", "path-rules")
-		if err == nil {
-			success = true
+		if err != nil {
+			return false, err
 		}
-
-		return
+		return true, nil
 	},
 }
 
+// placeholder check for dividing the pathRulesCheck into a distinct hierarchy for Exact path tests
 var pathRulesExactCheck = &Check{
 	Name: "path-rules-exact",
 }
 
+// placeholder check for dividing the pathRulesCheck into a distinct hierarchy for Prefix path tests
 var pathRulesPrefixCheck = &Check{
 	Name: "path-rules-prefix",
 }
@@ -69,13 +71,13 @@ var pathRulesPrefixCheck = &Check{
 var pathRulesPrefixAllPathsCheck = &Check{
 	Name:        "path-rules-prefix-all-paths",
 	Description: "Ingress with prefix path rule '/' should match all paths",
-	Run: func(check *Check, config Config) (success bool, err error) {
-		req, res, err := captureRequest(fmt.Sprintf("http://%s", pathRulesHost), "path-rules")
+	Run: func(check *Check, config Config) (bool, error) {
+		req, res, err := captureRoundTrip(fmt.Sprintf("http://%s", pathRulesHost), "path-rules")
 		if err != nil {
-			return
+			return false, err
 		}
 
-		a := new(AssertionSet)
+		a := &AssertionSet{}
 		// Assert the request received from the downstream service
 		a.Equals(req.DownstreamServiceId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
 		a.Equals(req.Path, "/", "expected the request path would be '%s' but was '%s'")
@@ -83,24 +85,24 @@ var pathRulesPrefixAllPathsCheck = &Check{
 		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
-			success = true
+			return true, nil
 		} else {
 			fmt.Print(a)
 		}
-		return
+		return false, nil
 	},
 }
 
 var pathRulesPrefixFooCheck = &Check{
 	Name:        "path-rules-prefix-foo",
 	Description: "Ingress with prefix path rule without a trailing slash should send traffic to the correct backend service, and preserve the original request path (/foo matches /foo)",
-	Run: func(check *Check, config Config) (success bool, err error) {
-		req, res, err := captureRequest(fmt.Sprintf("http://%s/foo", pathRulesHost), "path-rules")
+	Run: func(check *Check, config Config) (bool, error) {
+		req, res, err := captureRoundTrip(fmt.Sprintf("http://%s/foo", pathRulesHost), "path-rules")
 		if err != nil {
-			return
+			return false, err
 		}
 
-		a := new(AssertionSet)
+		a := &AssertionSet{}
 		// Assert the request received from the downstream service
 		a.Equals(req.DownstreamServiceId, "path-rules-foo", "expected the downstream service would be '%s' but was '%s'")
 		a.Equals(req.Path, "/foo", "expected the request path would be '%s' but was '%s'")
@@ -108,24 +110,24 @@ var pathRulesPrefixFooCheck = &Check{
 		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
-			success = true
+			return true, nil
 		} else {
 			fmt.Print(a)
 		}
-		return
+		return false, nil
 	},
 }
 
 var pathRulesPrefixFooSlashCheck = &Check{
 	Name:        "path-rules-prefix-foo-slash",
 	Description: "Ingress with prefix path rule without a trailing slash should send traffic to the correct backend service, and preserve the original request path (/foo matches /foo/)",
-	Run: func(check *Check, config Config) (success bool, err error) {
-		req, res, err := captureRequest(fmt.Sprintf("http://%s/foo/", pathRulesHost), "path-rules")
+	Run: func(check *Check, config Config) (bool, error) {
+		req, res, err := captureRoundTrip(fmt.Sprintf("http://%s/foo/", pathRulesHost), "path-rules")
 		if err != nil {
-			return
+			return false, err
 		}
 
-		a := new(AssertionSet)
+		a := &AssertionSet{}
 		// Assert the request received from the downstream service
 		a.Equals(req.DownstreamServiceId, "path-rules-foo", "expected the downstream service would be '%s' but was '%s'")
 		a.Equals(req.Path, "/foo/", "expected the request path would be '%s' but was '%s'")
@@ -133,24 +135,24 @@ var pathRulesPrefixFooSlashCheck = &Check{
 		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
-			success = true
+			return true, nil
 		} else {
 			fmt.Print(a)
 		}
-		return
+		return false, nil
 	},
 }
 
 var pathRulesPrefixFoCheck = &Check{
 	Name:        "path-rules-prefix-fo",
 	Description: "Ingress with prefix path rule without a trailing slash should not match partial paths (/foo does not match /fo)",
-	Run: func(check *Check, config Config) (success bool, err error) {
-		req, res, err := captureRequest(fmt.Sprintf("http://%s/fo", pathRulesHost), "path-rules")
+	Run: func(check *Check, config Config) (bool, error) {
+		req, res, err := captureRoundTrip(fmt.Sprintf("http://%s/fo", pathRulesHost), "path-rules")
 		if err != nil {
-			return
+			return false, err
 		}
 
-		a := new(AssertionSet)
+		a := &AssertionSet{}
 		// Assert the request received from the downstream service
 		a.Equals(req.DownstreamServiceId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
 		a.Equals(req.Path, "/fo", "expected the request path would be '%s' but was '%s'")
@@ -158,24 +160,24 @@ var pathRulesPrefixFoCheck = &Check{
 		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
-			success = true
+			return true, nil
 		} else {
 			fmt.Print(a)
 		}
-		return
+		return false, nil
 	},
 }
 
 var pathRulesPrefixAaaBbbCheck = &Check{
 	Name:        "path-rules-prefix-aaa-bbb",
 	Description: "Ingress with prefix path rule with a trailing slash should send traffic to the correct backend service, and preserve the original request path (/aaa/bbb/ matches /aaa/bbb)",
-	Run: func(check *Check, config Config) (success bool, err error) {
-		req, res, err := captureRequest(fmt.Sprintf("http://%s/aaa/bbb", pathRulesHost), "path-rules")
+	Run: func(check *Check, config Config) (bool, error) {
+		req, res, err := captureRoundTrip(fmt.Sprintf("http://%s/aaa/bbb", pathRulesHost), "path-rules")
 		if err != nil {
-			return
+			return false, err
 		}
 
-		a := new(AssertionSet)
+		a := &AssertionSet{}
 		// Assert the request received from the downstream service
 		a.Equals(req.DownstreamServiceId, "path-rules-aaa-bbb", "expected the downstream service would be '%s' but was '%s'")
 		a.Equals(req.Path, "/aaa/bbb", "expected the request path would be '%s' but was '%s'")
@@ -183,24 +185,24 @@ var pathRulesPrefixAaaBbbCheck = &Check{
 		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
-			success = true
+			return true, nil
 		} else {
 			fmt.Print(a)
 		}
-		return
+		return false, nil
 	},
 }
 
 var pathRulesPrefixAaaBbbSlashCheck = &Check{
 	Name:        "path-rules-prefix-aaa-bbb-slash",
 	Description: "Ingress with prefix path rule with a trailing slash should send traffic to the correct backend service, and preserve the original request path (/aaa/bbb/ matches /aaa/bbb/)",
-	Run: func(check *Check, config Config) (success bool, err error) {
-		req, res, err := captureRequest(fmt.Sprintf("http://%s/aaa/bbb/", pathRulesHost), "path-rules")
+	Run: func(check *Check, config Config) (bool, error) {
+		req, res, err := captureRoundTrip(fmt.Sprintf("http://%s/aaa/bbb/", pathRulesHost), "path-rules")
 		if err != nil {
-			return
+			return false, err
 		}
 
-		a := new(AssertionSet)
+		a := &AssertionSet{}
 		// Assert the request received from the downstream service
 		a.Equals(req.DownstreamServiceId, "path-rules-aaa-bbb", "expected the downstream service would be '%s' but was '%s'")
 		a.Equals(req.Path, "/aaa/bbb/", "expected the request path would be '%s' but was '%s'")
@@ -208,24 +210,24 @@ var pathRulesPrefixAaaBbbSlashCheck = &Check{
 		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
-			success = true
+			return true, nil
 		} else {
 			fmt.Print(a)
 		}
-		return
+		return false, nil
 	},
 }
 
 var pathRulesPrefixAaaBbbCccCheck = &Check{
 	Name:        "path-rules-prefix-aaa-bbb-ccc",
 	Description: "Ingress with prefix path rule with a trailing slash should match subpath, send traffic to the correct backend service, and preserve the original request path (/aaa/bbb/ matches /aaa/bbb/ccc)",
-	Run: func(check *Check, config Config) (success bool, err error) {
-		req, res, err := captureRequest(fmt.Sprintf("http://%s/aaa/bbb/ccc", pathRulesHost), "path-rules")
+	Run: func(check *Check, config Config) (bool, error) {
+		req, res, err := captureRoundTrip(fmt.Sprintf("http://%s/aaa/bbb/ccc", pathRulesHost), "path-rules")
 		if err != nil {
-			return
+			return false, err
 		}
 
-		a := new(AssertionSet)
+		a := &AssertionSet{}
 		// Assert the request received from the downstream service
 		a.Equals(req.DownstreamServiceId, "path-rules-aaa-bbb", "expected the downstream service would be '%s' but was '%s'")
 		a.Equals(req.Path, "/aaa/bbb/ccc", "expected the request path would be '%s' but was '%s'")
@@ -233,24 +235,24 @@ var pathRulesPrefixAaaBbbCccCheck = &Check{
 		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
-			success = true
+			return true, nil
 		} else {
 			fmt.Print(a)
 		}
-		return
+		return false, nil
 	},
 }
 
 var pathRulesPrefixAaaBbbcccCheck = &Check{
 	Name:        "path-rules-prefix-aaa-bbbccc",
 	Description: "Ingress with prefix path rule with a trailing slash should not match string prefix (/aaa/bbb/ does not match /aaa/bbbccc)",
-	Run: func(check *Check, config Config) (success bool, err error) {
-		req, res, err := captureRequest(fmt.Sprintf("http://%s/aaa/bbbccc", pathRulesHost), "path-rules")
+	Run: func(check *Check, config Config) (bool, error) {
+		req, res, err := captureRoundTrip(fmt.Sprintf("http://%s/aaa/bbbccc", pathRulesHost), "path-rules")
 		if err != nil {
-			return
+			return false, err
 		}
 
-		a := new(AssertionSet)
+		a := &AssertionSet{}
 		// Assert the request received from the downstream service
 		a.Equals(req.DownstreamServiceId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
 		a.Equals(req.Path, "/aaa/bbbccc", "expected the request path would be '%s' but was '%s'")
@@ -258,24 +260,24 @@ var pathRulesPrefixAaaBbbcccCheck = &Check{
 		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
-			success = true
+			return true, nil
 		} else {
 			fmt.Print(a)
 		}
-		return
+		return false, nil
 	},
 }
 
 var pathRulesPrefixConsecutiveSlashesCheck = &Check{
 	Name:        "path-rules-prefix-consecutive-slashes",
 	Description: "Ingress with prefix path rule with consecutive slashes are ignored",
-	Run: func(check *Check, config Config) (success bool, err error) {
-		req, res, err := captureRequest(fmt.Sprintf("http://%s/routes/with/consecutive//slashes///are-ignored", pathRulesHost), "path-rules")
+	Run: func(check *Check, config Config) (bool, error) {
+		req, res, err := captureRoundTrip(fmt.Sprintf("http://%s/routes/with/consecutive//slashes///are-ignored", pathRulesHost), "path-rules")
 		if err != nil {
-			return
+			return false, err
 		}
 
-		a := new(AssertionSet)
+		a := &AssertionSet{}
 		// Assert the request received from the downstream service
 		a.Equals(req.DownstreamServiceId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
 		a.Equals(req.Path, "/routes/with/consecutive//slashes///are-ignored", "expected the request path would be '%s' but was '%s'")
@@ -283,24 +285,24 @@ var pathRulesPrefixConsecutiveSlashesCheck = &Check{
 		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
-			success = true
+			return true, nil
 		} else {
 			fmt.Print(a)
 		}
-		return
+		return false, nil
 	},
 }
 
 var pathRulesPrefixConsecutiveSlashesNormalizedCheck = &Check{
 	Name:        "path-rules-prefix-consecutive-slashes-normalized",
 	Description: "Ingress with prefix path rule with consecutive slashes are ignored with normalized request",
-	Run: func(check *Check, config Config) (success bool, err error) {
-		req, res, err := captureRequest(fmt.Sprintf("http://%s/routes/with/consecutive/slashes/are-ignored", pathRulesHost), "path-rules")
+	Run: func(check *Check, config Config) (bool, error) {
+		req, res, err := captureRoundTrip(fmt.Sprintf("http://%s/routes/with/consecutive/slashes/are-ignored", pathRulesHost), "path-rules")
 		if err != nil {
-			return
+			return false, err
 		}
 
-		a := new(AssertionSet)
+		a := &AssertionSet{}
 		// Assert the request received from the downstream service
 		a.Equals(req.DownstreamServiceId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
 		a.Equals(req.Path, "/routes/with/consecutive/slashes/are-ignored", "expected the request path would be '%s' but was '%s'")
@@ -308,24 +310,24 @@ var pathRulesPrefixConsecutiveSlashesNormalizedCheck = &Check{
 		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
-			success = true
+			return true, nil
 		} else {
 			fmt.Print(a)
 		}
-		return
+		return false, nil
 	},
 }
 
 var pathRulesPrefixInvalidCharactersCheck = &Check{
 	Name:        "path-rules-prefix-invalid-characters",
 	Description: "Ingress with prefix path rule with invalid characters are ignored",
-	Run: func(check *Check, config Config) (success bool, err error) {
-		req, res, err := captureRequest(fmt.Sprintf("http://%s/routes with invalid characters are ignored!", pathRulesHost), "path-rules")
+	Run: func(check *Check, config Config) (bool, error) {
+		req, res, err := captureRoundTrip(fmt.Sprintf("http://%s/routes with invalid characters are ignored!", pathRulesHost), "path-rules")
 		if err != nil {
-			return
+			return false, err
 		}
 
-		a := new(AssertionSet)
+		a := &AssertionSet{}
 		// Assert the request received from the downstream service
 		a.Equals(req.DownstreamServiceId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
 		a.Equals(req.Path, "/routes%20with%20invalid%20characters%20are%20ignored%21", "expected the request path would be '%s' but was '%s'")
@@ -333,10 +335,10 @@ var pathRulesPrefixInvalidCharactersCheck = &Check{
 		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
-			success = true
+			return true, nil
 		} else {
 			fmt.Print(a)
 		}
-		return
+		return false, nil
 	},
 }

--- a/internal/pkg/checks/pathRulesCheck.go
+++ b/internal/pkg/checks/pathRulesCheck.go
@@ -319,7 +319,7 @@ var pathRulesPrefixConsecutiveSlashesCheck = &Check{
 
 var pathRulesPrefixConsecutiveSlashesNormalizedCheck = &Check{
 	Name:        "path-rules-prefix-consecutive-slashes-normalized",
-	Description: "Ingress with prefix path rule with consecutive slashes are ignored",
+	Description: "Ingress with prefix path rule with consecutive slashes are ignored with normalized request",
 	Run: func(check *Check, config Config) (success bool, err error) {
 		req, res, err := captureRequest(fmt.Sprintf("http://%s/routes/with/consecutive/slashes/are-ignored", pathRulesHost), "path-rules")
 		if err != nil {
@@ -344,7 +344,7 @@ var pathRulesPrefixConsecutiveSlashesNormalizedCheck = &Check{
 
 var pathRulesPrefixInvalidCharactersCheck = &Check{
 	Name:        "path-rules-prefix-invalid-characters",
-	Description: "Ingress with prefix path rule with consecutive slashes are ignored",
+	Description: "Ingress with prefix path rule with invalid characters are ignored",
 	Run: func(check *Check, config Config) (success bool, err error) {
 		req, res, err := captureRequest(fmt.Sprintf("http://%s/routes with invalid characters are ignored!", pathRulesHost), "path-rules")
 		if err != nil {

--- a/internal/pkg/checks/pathRulesCheck.go
+++ b/internal/pkg/checks/pathRulesCheck.go
@@ -79,10 +79,10 @@ var pathRulesPrefixAllPathsCheck = &Check{
 
 		a := &AssertionSet{}
 		// Assert the request received from the downstream service
-		a.Equals(req.DownstreamServiceId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
-		a.Equals(req.Path, "/", "expected the request path would be '%s' but was '%s'")
+		a.DeepEquals(req.DownstreamServiceId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
+		a.DeepEquals(req.Path, "/", "expected the request path would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.DeepEquals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			return true, nil
@@ -104,10 +104,10 @@ var pathRulesPrefixFooCheck = &Check{
 
 		a := &AssertionSet{}
 		// Assert the request received from the downstream service
-		a.Equals(req.DownstreamServiceId, "path-rules-foo", "expected the downstream service would be '%s' but was '%s'")
-		a.Equals(req.Path, "/foo", "expected the request path would be '%s' but was '%s'")
+		a.DeepEquals(req.DownstreamServiceId, "path-rules-foo", "expected the downstream service would be '%s' but was '%s'")
+		a.DeepEquals(req.Path, "/foo", "expected the request path would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.DeepEquals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			return true, nil
@@ -129,10 +129,10 @@ var pathRulesPrefixFooSlashCheck = &Check{
 
 		a := &AssertionSet{}
 		// Assert the request received from the downstream service
-		a.Equals(req.DownstreamServiceId, "path-rules-foo", "expected the downstream service would be '%s' but was '%s'")
-		a.Equals(req.Path, "/foo/", "expected the request path would be '%s' but was '%s'")
+		a.DeepEquals(req.DownstreamServiceId, "path-rules-foo", "expected the downstream service would be '%s' but was '%s'")
+		a.DeepEquals(req.Path, "/foo/", "expected the request path would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.DeepEquals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			return true, nil
@@ -154,10 +154,10 @@ var pathRulesPrefixFoCheck = &Check{
 
 		a := &AssertionSet{}
 		// Assert the request received from the downstream service
-		a.Equals(req.DownstreamServiceId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
-		a.Equals(req.Path, "/fo", "expected the request path would be '%s' but was '%s'")
+		a.DeepEquals(req.DownstreamServiceId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
+		a.DeepEquals(req.Path, "/fo", "expected the request path would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.DeepEquals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			return true, nil
@@ -179,10 +179,10 @@ var pathRulesPrefixAaaBbbCheck = &Check{
 
 		a := &AssertionSet{}
 		// Assert the request received from the downstream service
-		a.Equals(req.DownstreamServiceId, "path-rules-aaa-bbb", "expected the downstream service would be '%s' but was '%s'")
-		a.Equals(req.Path, "/aaa/bbb", "expected the request path would be '%s' but was '%s'")
+		a.DeepEquals(req.DownstreamServiceId, "path-rules-aaa-bbb", "expected the downstream service would be '%s' but was '%s'")
+		a.DeepEquals(req.Path, "/aaa/bbb", "expected the request path would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.DeepEquals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			return true, nil
@@ -204,10 +204,10 @@ var pathRulesPrefixAaaBbbSlashCheck = &Check{
 
 		a := &AssertionSet{}
 		// Assert the request received from the downstream service
-		a.Equals(req.DownstreamServiceId, "path-rules-aaa-bbb", "expected the downstream service would be '%s' but was '%s'")
-		a.Equals(req.Path, "/aaa/bbb/", "expected the request path would be '%s' but was '%s'")
+		a.DeepEquals(req.DownstreamServiceId, "path-rules-aaa-bbb", "expected the downstream service would be '%s' but was '%s'")
+		a.DeepEquals(req.Path, "/aaa/bbb/", "expected the request path would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.DeepEquals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			return true, nil
@@ -229,10 +229,10 @@ var pathRulesPrefixAaaBbbCccCheck = &Check{
 
 		a := &AssertionSet{}
 		// Assert the request received from the downstream service
-		a.Equals(req.DownstreamServiceId, "path-rules-aaa-bbb", "expected the downstream service would be '%s' but was '%s'")
-		a.Equals(req.Path, "/aaa/bbb/ccc", "expected the request path would be '%s' but was '%s'")
+		a.DeepEquals(req.DownstreamServiceId, "path-rules-aaa-bbb", "expected the downstream service would be '%s' but was '%s'")
+		a.DeepEquals(req.Path, "/aaa/bbb/ccc", "expected the request path would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.DeepEquals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			return true, nil
@@ -254,10 +254,10 @@ var pathRulesPrefixAaaBbbcccCheck = &Check{
 
 		a := &AssertionSet{}
 		// Assert the request received from the downstream service
-		a.Equals(req.DownstreamServiceId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
-		a.Equals(req.Path, "/aaa/bbbccc", "expected the request path would be '%s' but was '%s'")
+		a.DeepEquals(req.DownstreamServiceId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
+		a.DeepEquals(req.Path, "/aaa/bbbccc", "expected the request path would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.DeepEquals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			return true, nil
@@ -279,10 +279,10 @@ var pathRulesPrefixConsecutiveSlashesCheck = &Check{
 
 		a := &AssertionSet{}
 		// Assert the request received from the downstream service
-		a.Equals(req.DownstreamServiceId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
-		a.Equals(req.Path, "/routes/with/consecutive//slashes///are-ignored", "expected the request path would be '%s' but was '%s'")
+		a.DeepEquals(req.DownstreamServiceId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
+		a.DeepEquals(req.Path, "/routes/with/consecutive//slashes///are-ignored", "expected the request path would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.DeepEquals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			return true, nil
@@ -304,10 +304,10 @@ var pathRulesPrefixConsecutiveSlashesNormalizedCheck = &Check{
 
 		a := &AssertionSet{}
 		// Assert the request received from the downstream service
-		a.Equals(req.DownstreamServiceId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
-		a.Equals(req.Path, "/routes/with/consecutive/slashes/are-ignored", "expected the request path would be '%s' but was '%s'")
+		a.DeepEquals(req.DownstreamServiceId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
+		a.DeepEquals(req.Path, "/routes/with/consecutive/slashes/are-ignored", "expected the request path would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.DeepEquals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			return true, nil
@@ -329,10 +329,10 @@ var pathRulesPrefixInvalidCharactersCheck = &Check{
 
 		a := &AssertionSet{}
 		// Assert the request received from the downstream service
-		a.Equals(req.DownstreamServiceId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
-		a.Equals(req.Path, "/routes%20with%20invalid%20characters%20are%20ignored%21", "expected the request path would be '%s' but was '%s'")
+		a.DeepEquals(req.DownstreamServiceId, "path-rules-catchall", "expected the downstream service would be '%s' but was '%s'")
+		a.DeepEquals(req.Path, "/routes%20with%20invalid%20characters%20are%20ignored%21", "expected the request path would be '%s' but was '%s'")
 		// Assert the downstream service response
-		a.Equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.DeepEquals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			return true, nil

--- a/internal/pkg/checks/pathRulesCheck.go
+++ b/internal/pkg/checks/pathRulesCheck.go
@@ -47,15 +47,17 @@ var pathRulesFooCheck = &Check{
 	Name:        "path-rules-foo",
 	Description: "[SAMPLE] Ingress with path rule without a trailing slash should send traffic to the correct backend service, and preserve the original request path",
 	Run: func(check *Check, config Config) (success bool, err error) {
-		resp, err := captureRequest(fmt.Sprintf("http://%s/foo", host), "")
+		req, res, err := captureRequest(fmt.Sprintf("http://%s/foo", host), "")
 		if err != nil {
 			return
 		}
 
 		a := new(assertionSet)
-		a.equals(assert{resp.StatusCode, 200, "Expected StatusCode to be %s but was %s"})
-		a.equals(assert{resp.TestId, "path-rules-foo", "Expected the responding service would be '%s' but was '%s'"})
-		a.equals(assert{resp.Path, "/foo", "Expected the request path would be '%s' but was '%s'"})
+		// Assert the request received from the downstream service
+		a.equals(req.TestId, "path-rules-foo", "expected the downstream service would be '%s' but was '%s'")
+		a.equals(req.Path, "/foo", "expected the request path would be '%s' but was '%s'")
+		// Assert the downstream service response
+		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			success = true
@@ -70,15 +72,17 @@ var pathRulesFooTrailingSlashCheck = &Check{
 	Name:        "path-rules-foo-trailing",
 	Description: "[SAMPLE] Ingress with path rule without a trailing slash should send traffic to the correct backend service, and preserve the original request including sub-paths",
 	Run: func(check *Check, config Config) (success bool, err error) {
-		resp, err := captureRequest(fmt.Sprintf("http://%s/foo/", host), "")
+		req, res, err := captureRequest(fmt.Sprintf("http://%s/foo/", host), "")
 		if err != nil {
 			return
 		}
 
 		a := new(assertionSet)
-		a.equals(assert{resp.StatusCode, 200, "Expected StatusCode to be %s but was %s"})
-		a.equals(assert{resp.TestId, "path-rules-foo", "Expected the responding service would be '%s' but was '%s'"})
-		a.equals(assert{resp.Path, "/foo/", "Expected the request path would be '%s' but was '%s'"})
+		// Assert the request received from the downstream service
+		a.equals(req.TestId, "path-rules-foo", "expected the downstream service would be '%s' but was '%s'")
+		a.equals(req.Path, "/foo/", "expected the request path would be '%s' but was '%s'")
+		// Assert the downstream service response
+		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			success = true
@@ -93,15 +97,17 @@ var pathRulesBarCheck = &Check{
 	Name:        "path-rules-bar",
 	Description: "[SAMPLE] Ingress with path rule with a trailing slash should send traffic to the correct backend service, and preserve the original request path",
 	Run: func(check *Check, config Config) (success bool, err error) {
-		resp, err := captureRequest(fmt.Sprintf("http://%s/bar/", host), "")
+		req, res, err := captureRequest(fmt.Sprintf("http://%s/bar/", host), "")
 		if err != nil {
 			return
 		}
 
 		a := new(assertionSet)
-		a.equals(assert{resp.StatusCode, 200, "Expected StatusCode to be %s but was %s"})
-		a.equals(assert{resp.TestId, "path-rules-bar", "Expected the responding service would be '%s' but was '%s'"})
-		a.equals(assert{resp.Path, "/bar/", "Expected the request path would be '%s' but was '%s'"})
+		// Assert the request received from the downstream service
+		a.equals(req.TestId, "path-rules-bar", "expected the downstream service would be '%s' but was '%s'")
+		a.equals(req.Path, "/bar/", "expected the request path would be '%s' but was '%s'")
+		// Assert the downstream service response
+		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			success = true
@@ -116,15 +122,17 @@ var pathRulesBarSubpathCheck = &Check{
 	Name:        "path-rules-bar-subpath",
 	Description: "[SAMPLE] Ingress with path rule with a trailing slash should send traffic to the correct backend service, and preserve the original request including sub-paths and double '/'",
 	Run: func(check *Check, config Config) (success bool, err error) {
-		resp, err := captureRequest(fmt.Sprintf("http://%s/bar//bershop", host), "")
+		req, res, err := captureRequest(fmt.Sprintf("http://%s/bar//bershop", host), "")
 		if err != nil {
 			return
 		}
 
 		a := new(assertionSet)
-		a.equals(assert{resp.StatusCode, 200, "Expected StatusCode to be %s but was %s"})
-		a.equals(assert{resp.TestId, "path-rules-bar", "Expected the responding service would be '%s' but was '%s'"})
-		a.equals(assert{resp.Path, "/bar//bershop", "Expected the request path would be '%s' but was '%s'"})
+		// Assert the request received from the downstream service
+		a.equals(req.TestId, "path-rules-bar", "expected the downstream service would be '%s' but was '%s'")
+		a.equals(req.Path, "/bar//bershop", "expected the request path would be '%s' but was '%s'")
+		// Assert the downstream service response
+		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			success = true

--- a/internal/pkg/checks/singleServiceCheck.go
+++ b/internal/pkg/checks/singleServiceCheck.go
@@ -27,7 +27,7 @@ func init() {
 
 var singleServiceCheck = &Check{
 	Name:        "single-service",
-	Description: "Ingress with no rules should send traffic to the correct backend service",
+	Description: "Ingress with single-service should send traffic to the correct backend service",
 	Run: func(check *Check, config Config) (success bool, err error) {
 		host, err := k8s.GetIngressHost("default", "single-service")
 		if err != nil {
@@ -44,8 +44,11 @@ var singleServiceCheck = &Check{
 		a.equals(req.TestId, "single-service", "expected the downstream service would be '%s' but was '%s'")
 		a.equals(req.Method, "GET", "expected the originating request method would be '%s' but was '%s'")
 		a.equals(req.Proto, "HTTP/1.1", "expected the originating request protocol would be '%s' but was '%s'")
+		a.containsKeys(req.Headers, []string{"User-Agent"}, "expected the request headers would contain %s but contained %s")
 		// Assert the downstream service response
 		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
+		a.equals(res.Proto, "HTTP/1.1", "expected the response protocol would be %s but was %s")
+		a.containsOnlyKeys(res.Headers, []string{"Content-Length", "Content-Type", "Date", "Server"}, "expected the response headers would contain %s but contained %s")
 
 		if a.Error() == "" {
 			success = true

--- a/internal/pkg/checks/singleServiceCheck.go
+++ b/internal/pkg/checks/singleServiceCheck.go
@@ -34,14 +34,18 @@ var singleServiceCheck = &Check{
 			return
 		}
 
-		resp, err := captureRequest(fmt.Sprintf("http://%s", host), "")
+		req, res, err := captureRequest(fmt.Sprintf("http://%s", host), "")
 		if err != nil {
 			return
 		}
 
 		a := new(assertionSet)
-		a.equals(assert{resp.StatusCode, 200, "Expected StatusCode to be %s but was %s"})
-		a.equals(assert{resp.TestId, "single-service", "Expected the responding service would be '%s' but was '%s'"})
+		// Assert the request received from the downstream service
+		a.equals(req.TestId, "single-service", "expected the downstream service would be '%s' but was '%s'")
+		a.equals(req.Method, "GET", "expected the originating request method would be '%s' but was '%s'")
+		a.equals(req.Proto, "HTTP/1.1", "expected the originating request protocol would be '%s' but was '%s'")
+		// Assert the downstream service response
+		a.equals(res.StatusCode, 200, "expected statuscode to be %s but was %s")
 
 		if a.Error() == "" {
 			success = true

--- a/tools/echoserver.go
+++ b/tools/echoserver.go
@@ -38,6 +38,7 @@ type preserveSlashes struct {
 }
 
 func (s *preserveSlashes) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// preserve the original URL Path, don't let Go normalize it
 	r.URL.Path = strings.Replace(r.URL.Path, "//", "/", -1)
 	s.mux.ServeHTTP(w, r)
 }
@@ -89,6 +90,7 @@ func RequestHandler(response http.ResponseWriter, request *http.Request) {
 		return
 	}
 
+	// Go libs have no gzip support for HTTP responses, sending it uncompressed.
 	response.Header().Set("Content-Type", "application/json")
 	response.Write(js)
 }

--- a/tools/echoserver.go
+++ b/tools/echoserver.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 )
 
+// RequestAssertions contains the HTTP response which can be asserted
+// by checks.CapturedRequest
 type RequestAssertions struct {
 	TestId  string
 	Path    string

--- a/tools/echoserver.go
+++ b/tools/echoserver.go
@@ -93,6 +93,8 @@ func RequestHandler(response http.ResponseWriter, request *http.Request) {
 	}
 
 	// Go libs have no gzip support for HTTP responses, sending it uncompressed.
+	// If the client gets a compressed gzip response, it means the ingress-controller compressed it.
 	response.Header().Set("Content-Type", "application/json")
+
 	response.Write(js)
 }


### PR DESCRIPTION
- Improved README documentation with context and coverage.
- Reworked and augmented the conformance test suite with recent changes in KEP: https://github.com/kubernetes/enhancements/pull/1445

```
- Ingress with a single default backend should send traffic to the correct backend service [default-backend]
- Ingress with exact host rule should send traffic to the correct backend service [host-rules-exact-match]
- Ingress with wildcard host rule should match a single label [host-rules-wildcard-single-label]
- Ingress with wildcard host rule should only match a single label & fallback to default-backend [host-rules-wildcard-multiple-labels]
- Ingress with wildcard host rule should match exactly one single label & fallback to default-backend [host-rules-wildcard-no-label]
- Ingress with prefix path rule '/' should match all paths [path-rules-prefix-all-paths]
- Ingress with prefix path rule without a trailing slash should send traffic to the correct backend service, and preserve the original request path (/foo matches /foo) [path-rules-prefix-foo]
- Ingress with prefix path rule without a trailing slash should send traffic to the correct backend service, and preserve the original request path (/foo matches /foo/) [path-rules-prefix-foo-slash]
- Ingress with prefix path rule without a trailing slash should not match partial paths (/foo does not match /fo) [path-rules-prefix-fo]
- Ingress with prefix path rule with a trailing slash should send traffic to the correct backend service, and preserve the original request path (/aaa/bbb/ matches /aaa/bbb) [path-rules-prefix-aaa-bbb]
- Ingress with prefix path rule with a trailing slash should send traffic to the correct backend service, and preserve the original request path (/aaa/bbb/ matches /aaa/bbb/) [path-rules-prefix-aaa-bbb-slash]
- Ingress with prefix path rule with a trailing slash should match subpath, send traffic to the correct backend service, and preserve the original request path (/aaa/bbb/ matches /aaa/bbb/ccc) [path-rules-prefix-aaa-bbb-ccc]
- Ingress with prefix path rule with a trailing slash should not match partial paths (/aaa/bbb/ does not match /aaa/bb) [path-rules-prefix-aaa-bb]
- Ingress with prefix path rule with a trailing slash should not match string prefix (/aaa/bbb/ does not match /aaa/bbbccc) [path-rules-prefix-aaa-bbbccc]
- Ingress with prefix path rule with consecutive slashes are ignored [path-rules-prefix-consecutive-slashes]
- Ingress with prefix path rule with consecutive slashes are ignored with normalized request [path-rules-prefix-consecutive-slashes-normalized]
- Ingress with prefix path rule with invalid characters are ignored [path-rules-prefix-invalid-characters]
```

/sig network
/cc @bowei @robscott