### PR TITLE
Lazy load the Kubernetes client context.

### DIFF
--- a/cmd/context.go
+++ b/cmd/context.go
@@ -31,17 +31,17 @@ var contextCmd = &cobra.Command{
 	Short: "Print the current Kubernetes context, server version, and supported Ingress APIVersions",
 	Long:  "Print the current Kubernetes context, server version, and supported Ingress APIVersions then exits",
 	Run: func(cmd *cobra.Command, args []string) {
-		serverVersion, err := k8s.Client.ServerVersion()
+		serverVersion, err := k8s.Client().ServerVersion()
 		if err != nil {
 			panic(err.Error())
 		}
 
-		resources, err := k8s.Client.ServerPreferredResources()
+		resources, err := k8s.Client().ServerPreferredResources()
 		if err != nil {
 			panic(err.Error())
 		}
 
-		fmt.Printf("Using active Kubernetes context '%s'\n", k8s.Config.CurrentContext)
+		fmt.Printf("Using active Kubernetes context '%s'\n", k8s.Config().CurrentContext)
 		fmt.Printf("The target Kubernetes cluster is running verion %s\n", serverVersion)
 		for _, resource := range resources {
 			for _, apiResource := range resource.APIResources {

--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -36,7 +36,7 @@ var rootCmd = &cobra.Command{
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
If we require the Kubernetes context to be loaded by an init function,
not even the help text can be shown without the user having a
current Kubernetes config. Switch over to lazily loading the cluster
configuration, which results in a similar API, but avoids the problems
around init functions.

Signed-off-by: James Peach <jpeach@vmware.com>