### PR TITLE
Feature behavior definitions for default-backend, host-rules and path-rules with codegen

### DIFF
--- a/conformance_test.go
+++ b/conformance_test.go
@@ -32,7 +32,8 @@ import (
 	"k8s.io/klog"
 
 	"sigs.k8s.io/ingress-controller-conformance/test/conformance/defaultbackend"
-	"sigs.k8s.io/ingress-controller-conformance/test/files"
+	"sigs.k8s.io/ingress-controller-conformance/test/conformance/hostrules"
+	"sigs.k8s.io/ingress-controller-conformance/test/conformance/pathrules"
 	"sigs.k8s.io/ingress-controller-conformance/test/kubernetes"
 )
 
@@ -42,8 +43,6 @@ var (
 	godogStopOnFailure bool
 	godogNoColors      bool
 	godogOutput        string
-
-	manifests string
 )
 
 func TestMain(m *testing.M) {
@@ -54,7 +53,6 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&godogTags, "tags", "", "Tags for conformance test")
 	flag.BoolVar(&godogStopOnFailure, "stop-on-failure ", false, "Stop when failure is found")
 	flag.BoolVar(&godogNoColors, "no-colors", false, "Disable colors in godog output")
-	flag.StringVar(&manifests, "manifests", "./manifests", "Directory where manifests for test applications or scenerarios are located")
 	flag.StringVar(&godogOutput, "output-directory", ".", "Output directory for test reports")
 	flag.StringVar(&kubernetes.IngressClassValue, "ingress-class", "conformance", "Sets the value of the annotation kubernetes.io/ingress.class in Ingress definitions")
 
@@ -65,15 +63,7 @@ func TestMain(m *testing.M) {
 		klog.Fatalf("the godog format '%v' is not supported", godogFormat)
 	}
 
-	manifestsPath, err := filepath.Abs(manifests)
-	if err != nil {
-		klog.Fatal(err)
-	}
-
-	if !files.IsDir(manifestsPath) {
-		klog.Fatalf("The specified value in the flag --manifests-directory (%v) is not a directory", manifests)
-	}
-
+	var err error
 	kubernetes.KubeClient, err = setupSuite()
 	if err != nil {
 		klog.Fatal(err)
@@ -111,6 +101,8 @@ func setupSuite() (*clientset.Clientset, error) {
 var (
 	features = map[string]func(*godog.Suite){
 		"features/default_backend.feature": defaultbackend.FeatureContext,
+		"features/host_rules.feature":      hostrules.FeatureContext,
+		"features/path_rules.feature":      pathrules.FeatureContext,
 	}
 )
 

--- a/features/host_rules.feature
+++ b/features/host_rules.feature
@@ -1,0 +1,55 @@
+@sig-network @conformance @release-1.19
+Feature: Host rules
+
+  An Ingress may define routing rules based on the request host.
+
+  If the HTTP request host matches one of the hosts in the
+  Ingress objects, the traffic is routed to its backend service.
+
+  Background:
+    Given a new random namespace
+    Given a self-signed TLS secret named "conformance-tls" for the "foo.bar.com" hostname
+    Given an Ingress resource
+      """
+      apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      metadata:
+        name: host-rules
+      spec:
+        tls:
+          - hosts:
+              - foo.bar.com
+            secretName: conformance-tls
+        rules:
+          - host: "*.bar.com"
+            http:
+              paths:
+                - path: /
+                  backend:
+                    service:
+                      name: host-rules-wildcard-bar-com
+                      port:
+                        number: 80
+          - host: foo.bar.com
+            http:
+              paths:
+                - backend:
+                    service:
+                      name: host-rules-foo-bar-com
+                      port:
+                        name: http
+      """
+    Then The Ingress status shows the IP address or FQDN where it is exposed
+
+  Scenario: An Ingress with a host rule should send traffic to the matching backend service
+    When I send a "GET" request to "https://foo.bar.com"
+    Then the secure connection must verify the "foo.bar.com" hostname
+    And the response status-code must be 200
+    And the response must be served by the "host-rules-foo-bar-com" service
+    And the request host must be "foo.bar.com"
+
+  Scenario: An Ingress with a wildcard host rule should send traffic to the matching backend service
+    When I send a "GET" request to "http://wildcard.bar.com"
+    Then the response status-code must be 200
+    And the response must be served by the "host-rules-wildcard-bar-com" service
+    And the request host must be "wildcard.bar.com"

--- a/features/path_rules.feature
+++ b/features/path_rules.feature
@@ -1,0 +1,51 @@
+@sig-network @conformance @release-1.19
+Feature: Path rules
+
+  An Ingress may define routing rules based on the request path.
+
+  If the HTTP request path matches one of the paths in the
+  Ingress objects, the traffic is routed to its backend service.
+
+  Background:
+    Given an Ingress resource in a new random namespace
+      """
+      apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      metadata:
+        name: path-rules
+      spec:
+        rules:
+          - host: "path-rules"
+            http:
+              paths:
+                - path: /foo
+                  pathType: Prefix
+                  backend:
+                    service:
+                      name: path-rules-foo
+                      port:
+                        number: 80
+
+                - path: /foo
+                  pathType: Exact
+                  backend:
+                    service:
+                      name: path-rules-exact
+                      port:
+                        number: 80
+      """
+    Then The Ingress status shows the IP address or FQDN where it is exposed
+
+  Scenario: An Ingress with a prefix path rule without a trailing slash should send traffic to the matching backend service
+  (exact /foo matches request /foo)
+    When I send a "GET" request to "http://path-rules/foo"
+    Then the response status-code must be 200
+    And the response must be served by the "path-rules-exact" service
+    And the request path must be "/foo"
+
+  Scenario: An Ingress with a prefix path rule with a trailing slash should send traffic to the matching backend service
+  (prefix /foo matches request /foo/)
+    When I send a "GET" request to "http://path-rules/foo/"
+    Then the response status-code must be 200
+    And the response must be served by the "path-rules-foo" service
+    And the request path must be "/foo/"

--- a/test/conformance/hostrules/feature.go
+++ b/test/conformance/hostrules/feature.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package defaultbackend
+package hostrules
 
 import (
 	"github.com/cucumber/godog"
@@ -32,17 +32,14 @@ var (
 // by hand but rather through make codegen. DO NOT EDIT.
 func FeatureContext(s *godog.Suite) {
 	s.Step(`^a new random namespace$`, aNewRandomNamespace)
-	s.Step(`^an Ingress resource named "([^"]*)" with this spec:$`, anIngressResourceNamedWithThisSpec)
+	s.Step(`^a self-signed TLS secret named "([^"]*)" for the "([^"]*)" hostname$`, aSelfsignedTLSSecretNamedForTheHostname)
+	s.Step(`^an Ingress resource$`, anIngressResource)
 	s.Step(`^The Ingress status shows the IP address or FQDN where it is exposed$`, theIngressStatusShowsTheIPAddressOrFQDNWhereItIsExposed)
-	s.Step(`^I send a "([^"]*)" request to http:\/\/"([^"]*)"\/"([^"]*)"$`, iSendARequestToHttp)
+	s.Step(`^I send a "([^"]*)" request to "([^"]*)"$`, iSendARequestTo)
+	s.Step(`^the secure connection must verify the "([^"]*)" hostname$`, theSecureConnectionMustVerifyTheHostname)
 	s.Step(`^the response status-code must be (\d+)$`, theResponseStatuscodeMustBe)
 	s.Step(`^the response must be served by the "([^"]*)" service$`, theResponseMustBeServedByTheService)
-	s.Step(`^the response proto must be "([^"]*)"$`, theResponseProtoMustBe)
-	s.Step(`^the response headers must contain <key> with matching <value>$`, theResponseHeadersMustContainKeyWithMatchingValue)
-	s.Step(`^the request method must be "([^"]*)"$`, theRequestMethodMustBe)
-	s.Step(`^the request path must be "([^"]*)"$`, theRequestPathMustBe)
-	s.Step(`^the request proto must be "([^"]*)"$`, theRequestProtoMustBe)
-	s.Step(`^the request headers must contain <key> with matching <value>$`, theRequestHeadersMustContainKeyWithMatchingValue)
+	s.Step(`^the request host must be "([^"]*)"$`, theRequestHostMustBe)
 
 	s.BeforeScenario(func(this *messages.Pickle) {
 		state = tstate.New(nil)
@@ -58,7 +55,11 @@ func aNewRandomNamespace() error {
 	return godog.ErrPending
 }
 
-func anIngressResourceNamedWithThisSpec(arg1 string, arg2 *messages.PickleStepArgument_PickleDocString) error {
+func aSelfsignedTLSSecretNamedForTheHostname(arg1 string, arg2 string) error {
+	return godog.ErrPending
+}
+
+func anIngressResource(arg1 *messages.PickleStepArgument_PickleDocString) error {
 	return godog.ErrPending
 }
 
@@ -66,7 +67,11 @@ func theIngressStatusShowsTheIPAddressOrFQDNWhereItIsExposed() error {
 	return godog.ErrPending
 }
 
-func iSendARequestToHttp(arg1 string, arg2 string, arg3 string) error {
+func iSendARequestTo(arg1 string, arg2 string) error {
+	return godog.ErrPending
+}
+
+func theSecureConnectionMustVerifyTheHostname(arg1 string) error {
 	return godog.ErrPending
 }
 
@@ -78,26 +83,6 @@ func theResponseMustBeServedByTheService(arg1 string) error {
 	return godog.ErrPending
 }
 
-func theResponseProtoMustBe(arg1 string) error {
-	return godog.ErrPending
-}
-
-func theResponseHeadersMustContainKeyWithMatchingValue(arg1 *messages.PickleStepArgument_PickleTable) error {
-	return godog.ErrPending
-}
-
-func theRequestMethodMustBe(arg1 string) error {
-	return godog.ErrPending
-}
-
-func theRequestPathMustBe(arg1 string) error {
-	return godog.ErrPending
-}
-
-func theRequestProtoMustBe(arg1 string) error {
-	return godog.ErrPending
-}
-
-func theRequestHeadersMustContainKeyWithMatchingValue(arg1 *messages.PickleStepArgument_PickleTable) error {
+func theRequestHostMustBe(arg1 string) error {
 	return godog.ErrPending
 }

--- a/test/conformance/pathrules/feature.go
+++ b/test/conformance/pathrules/feature.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package defaultbackend
+package pathrules
 
 import (
 	"github.com/cucumber/godog"
@@ -31,18 +31,12 @@ var (
 // IMPORTANT: Steps definitions are generated and should not be modified
 // by hand but rather through make codegen. DO NOT EDIT.
 func FeatureContext(s *godog.Suite) {
-	s.Step(`^a new random namespace$`, aNewRandomNamespace)
-	s.Step(`^an Ingress resource named "([^"]*)" with this spec:$`, anIngressResourceNamedWithThisSpec)
+	s.Step(`^an Ingress resource in a new random namespace$`, anIngressResourceInANewRandomNamespace)
 	s.Step(`^The Ingress status shows the IP address or FQDN where it is exposed$`, theIngressStatusShowsTheIPAddressOrFQDNWhereItIsExposed)
-	s.Step(`^I send a "([^"]*)" request to http:\/\/"([^"]*)"\/"([^"]*)"$`, iSendARequestToHttp)
+	s.Step(`^I send a "([^"]*)" request to "([^"]*)"$`, iSendARequestTo)
 	s.Step(`^the response status-code must be (\d+)$`, theResponseStatuscodeMustBe)
 	s.Step(`^the response must be served by the "([^"]*)" service$`, theResponseMustBeServedByTheService)
-	s.Step(`^the response proto must be "([^"]*)"$`, theResponseProtoMustBe)
-	s.Step(`^the response headers must contain <key> with matching <value>$`, theResponseHeadersMustContainKeyWithMatchingValue)
-	s.Step(`^the request method must be "([^"]*)"$`, theRequestMethodMustBe)
 	s.Step(`^the request path must be "([^"]*)"$`, theRequestPathMustBe)
-	s.Step(`^the request proto must be "([^"]*)"$`, theRequestProtoMustBe)
-	s.Step(`^the request headers must contain <key> with matching <value>$`, theRequestHeadersMustContainKeyWithMatchingValue)
 
 	s.BeforeScenario(func(this *messages.Pickle) {
 		state = tstate.New(nil)
@@ -54,11 +48,7 @@ func FeatureContext(s *godog.Suite) {
 	})
 }
 
-func aNewRandomNamespace() error {
-	return godog.ErrPending
-}
-
-func anIngressResourceNamedWithThisSpec(arg1 string, arg2 *messages.PickleStepArgument_PickleDocString) error {
+func anIngressResourceInANewRandomNamespace(arg1 *messages.PickleStepArgument_PickleDocString) error {
 	return godog.ErrPending
 }
 
@@ -66,7 +56,7 @@ func theIngressStatusShowsTheIPAddressOrFQDNWhereItIsExposed() error {
 	return godog.ErrPending
 }
 
-func iSendARequestToHttp(arg1 string, arg2 string, arg3 string) error {
+func iSendARequestTo(arg1 string, arg2 string) error {
 	return godog.ErrPending
 }
 
@@ -78,26 +68,6 @@ func theResponseMustBeServedByTheService(arg1 string) error {
 	return godog.ErrPending
 }
 
-func theResponseProtoMustBe(arg1 string) error {
-	return godog.ErrPending
-}
-
-func theResponseHeadersMustContainKeyWithMatchingValue(arg1 *messages.PickleStepArgument_PickleTable) error {
-	return godog.ErrPending
-}
-
-func theRequestMethodMustBe(arg1 string) error {
-	return godog.ErrPending
-}
-
 func theRequestPathMustBe(arg1 string) error {
-	return godog.ErrPending
-}
-
-func theRequestProtoMustBe(arg1 string) error {
-	return godog.ErrPending
-}
-
-func theRequestHeadersMustContainKeyWithMatchingValue(arg1 *messages.PickleStepArgument_PickleTable) error {
 	return godog.ErrPending
 }


### PR DESCRIPTION
Feature behavior definitions following Gherkin guidelines around step definitions and structure.

With this PR:
- Shows how to define a scenario
- Clear there are no external yaml definitions (are embedded in the feature)
- We will use one or more predefined docker images for the tests.
- No test implementation, definitions only.

A few notes:
- godog does not support the `Rule` keyword.
- Using `Background` to setup the Namespace and Ingress resources common to multiple scenarios. Experimenting with Doc Strings to define the Ingress resources rather than rely on external manifests.
- Each scenario is limited to 1 `When` keyword, describing an event (HTTP request).
- Experimenting with `Scenario Outline` and `Examples` to keep the default-backend features DRY.