### PR TITLE
Implementation of the existing feature scenario steps

### DIFF
--- a/hack/codegen.tmpl
+++ b/hack/codegen.tmpl
@@ -34,7 +34,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) { {{- range .NewFunctions }}
 	ctx.Step({{ backticked .Expr | unescape }}, {{ .Name }}){{end}}
 
 	ctx.BeforeScenario(func(*godog.Scenario) {
-		state = tstate.New(nil)
+		state = tstate.New()
 	})
 
 	ctx.AfterScenario(func(*messages.Pickle, error) {

--- a/test/conformance/defaultbackend/feature.go
+++ b/test/conformance/defaultbackend/feature.go
@@ -17,6 +17,8 @@ limitations under the License.
 package defaultbackend
 
 import (
+	"fmt"
+
 	"github.com/cucumber/godog"
 	"github.com/cucumber/messages-go/v10"
 
@@ -45,7 +47,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^the request headers must contain <key> with matching <value>$`, theRequestHeadersMustContainKeyWithMatchingValue)
 
 	ctx.BeforeScenario(func(*godog.Scenario) {
-		state = tstate.New(nil)
+		state = tstate.New()
 	})
 
 	ctx.AfterScenario(func(*messages.Pickle, error) {
@@ -66,38 +68,74 @@ func theIngressStatusShowsTheIPAddressOrFQDNWhereItIsExposed() error {
 	return godog.ErrPending
 }
 
-func iSendARequestToHttp(arg1 string, arg2 string, arg3 string) error {
-	return godog.ErrPending
+func iSendARequestToHttp(method string, hostname string, path string) error {
+	return state.CaptureRoundTrip(method, "http", hostname, path)
 }
 
-func theResponseStatuscodeMustBe(arg1 int) error {
-	return godog.ErrPending
+func theResponseStatuscodeMustBe(statusCode int) error {
+	return state.AssertStatusCode(statusCode)
 }
 
-func theResponseMustBeServedByTheService(arg1 string) error {
-	return godog.ErrPending
+func theResponseMustBeServedByTheService(service string) error {
+	return state.AssertServedBy(service)
 }
 
-func theResponseProtoMustBe(arg1 string) error {
-	return godog.ErrPending
+func theResponseProtoMustBe(proto string) error {
+	return state.AssertResponseProto(proto)
 }
 
-func theResponseHeadersMustContainKeyWithMatchingValue(arg1 *messages.PickleStepArgument_PickleTable) error {
-	return godog.ErrPending
+func theResponseHeadersMustContainKeyWithMatchingValue(headers *messages.PickleStepArgument_PickleTable) error {
+	if len(headers.Rows) < 1 {
+		return fmt.Errorf("expected a table with at least one row")
+	}
+
+	for i, row := range headers.Rows {
+		if i == 0 {
+			// Skip the header row
+			continue
+		}
+
+		headerKey := row.Cells[0].Value
+		headerValue := row.Cells[1].Value
+
+		if err := state.AssertResponseHeader(headerKey, headerValue); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
-func theRequestMethodMustBe(arg1 string) error {
-	return godog.ErrPending
+func theRequestMethodMustBe(method string) error {
+	return state.AssertMethod(method)
 }
 
-func theRequestPathMustBe(arg1 string) error {
-	return godog.ErrPending
+func theRequestPathMustBe(path string) error {
+	return state.AssertRequestPath(path)
 }
 
-func theRequestProtoMustBe(arg1 string) error {
-	return godog.ErrPending
+func theRequestProtoMustBe(proto string) error {
+	return state.AssertRequestProto(proto)
 }
 
-func theRequestHeadersMustContainKeyWithMatchingValue(arg1 *messages.PickleStepArgument_PickleTable) error {
-	return godog.ErrPending
+func theRequestHeadersMustContainKeyWithMatchingValue(headers *messages.PickleStepArgument_PickleTable) error {
+	if len(headers.Rows) < 1 {
+		return fmt.Errorf("expected a table with at least one row")
+	}
+
+	for i, row := range headers.Rows {
+		if i == 0 {
+			// Skip the header row
+			continue
+		}
+
+		headerKey := row.Cells[0].Value
+		headerValue := row.Cells[1].Value
+
+		if err := state.AssertRequestHeader(headerKey, headerValue); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/test/conformance/hostrules/feature.go
+++ b/test/conformance/hostrules/feature.go
@@ -17,6 +17,8 @@ limitations under the License.
 package hostrules
 
 import (
+	"net/url"
+
 	"github.com/cucumber/godog"
 	"github.com/cucumber/messages-go/v10"
 
@@ -42,7 +44,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^the request host must be "([^"]*)"$`, theRequestHostMustBe)
 
 	ctx.BeforeScenario(func(*godog.Scenario) {
-		state = tstate.New(nil)
+		state = tstate.New()
 	})
 
 	ctx.AfterScenario(func(*messages.Pickle, error) {
@@ -67,22 +69,26 @@ func theIngressStatusShowsTheIPAddressOrFQDNWhereItIsExposed() error {
 	return godog.ErrPending
 }
 
-func iSendARequestTo(arg1 string, arg2 string) error {
-	return godog.ErrPending
+func iSendARequestTo(method string, rawUrl string) error {
+	u, err := url.Parse(rawUrl)
+	if err != nil {
+		return err
+	}
+	return state.CaptureRoundTrip(method, u.Scheme, u.Host, u.Path)
 }
 
-func theSecureConnectionMustVerifyTheHostname(arg1 string) error {
-	return godog.ErrPending
+func theSecureConnectionMustVerifyTheHostname(hostname string) error {
+	return state.AssertTLSHostname(hostname)
 }
 
-func theResponseStatuscodeMustBe(arg1 int) error {
-	return godog.ErrPending
+func theResponseStatuscodeMustBe(statusCode int) error {
+	return state.AssertStatusCode(statusCode)
 }
 
-func theResponseMustBeServedByTheService(arg1 string) error {
-	return godog.ErrPending
+func theResponseMustBeServedByTheService(service string) error {
+	return state.AssertServedBy(service)
 }
 
-func theRequestHostMustBe(arg1 string) error {
-	return godog.ErrPending
+func theRequestHostMustBe(host string) error {
+	return state.AssertRequestHost(host)
 }

--- a/test/conformance/pathrules/feature.go
+++ b/test/conformance/pathrules/feature.go
@@ -17,6 +17,8 @@ limitations under the License.
 package pathrules
 
 import (
+	"net/url"
+
 	"github.com/cucumber/godog"
 	"github.com/cucumber/messages-go/v10"
 
@@ -39,7 +41,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^the request path must be "([^"]*)"$`, theRequestPathMustBe)
 
 	ctx.BeforeScenario(func(*godog.Scenario) {
-		state = tstate.New(nil)
+		state = tstate.New()
 	})
 
 	ctx.AfterScenario(func(*messages.Pickle, error) {
@@ -56,18 +58,22 @@ func theIngressStatusShowsTheIPAddressOrFQDNWhereItIsExposed() error {
 	return godog.ErrPending
 }
 
-func iSendARequestTo(arg1 string, arg2 string) error {
-	return godog.ErrPending
+func iSendARequestTo(method string, rawUrl string) error {
+	u, err := url.Parse(rawUrl)
+	if err != nil {
+		return err
+	}
+	return state.CaptureRoundTrip(method, u.Scheme, u.Host, u.Path)
 }
 
-func theResponseStatuscodeMustBe(arg1 int) error {
-	return godog.ErrPending
+func theResponseStatuscodeMustBe(statusCode int) error {
+	return state.AssertStatusCode(statusCode)
 }
 
-func theResponseMustBeServedByTheService(arg1 string) error {
-	return godog.ErrPending
+func theResponseMustBeServedByTheService(service string) error {
+	return state.AssertServedBy(service)
 }
 
-func theRequestPathMustBe(arg1 string) error {
-	return godog.ErrPending
+func theRequestPathMustBe(path string) error {
+	return state.AssertRequestPath(path)
 }

--- a/test/http/http.go
+++ b/test/http/http.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// CapturedRequest contains the original HTTP request metadata as received
+// by the echoserver handling the test request.
+type CapturedRequest struct {
+	DownstreamServiceId string `json:"testId"` // DownstreamServiceId field contains the TEST_ID environment variable value of the downstream echoserver.
+	Path                string
+	Host                string
+	Method              string
+	Proto               string
+	Headers             map[string][]string
+}
+
+// CapturedResponse contains the HTTP response metadata from the echoserver.
+type CapturedResponse struct {
+	StatusCode    int
+	ContentLength int64
+	Proto         string
+	Headers       map[string][]string
+	TLSHostname   string
+}
+
+// CaptureRoundTrip will perform an HTTP request and return the CapturedRequest and CapturedResponse tuple
+func CaptureRoundTrip(method, scheme, hostname, path, location string) (*CapturedRequest, *CapturedResponse, error) {
+	var capturedTLSHostname string
+	tr := &http.Transport{
+		DisableCompression: true,
+		TLSClientConfig: &tls.Config{
+			// Skip all usual TLS verifications, since we are using self-signed certificates.
+			InsecureSkipVerify: true,
+			VerifyPeerCertificate: func(certificates [][]byte, _ [][]*x509.Certificate) error {
+				certs := make([]*x509.Certificate, len(certificates))
+				for i, asn1Data := range certificates {
+					cert, err := x509.ParseCertificate(asn1Data)
+					if err != nil {
+						return fmt.Errorf("tls: failed to parse certificate from server: " + err.Error())
+					}
+					certs[i] = cert
+				}
+
+				// Verify the certificate Hostname matches the request hostname.
+				capturedTLSHostname = hostname
+				return certs[0].VerifyHostname(hostname)
+			},
+		},
+	}
+	client := &http.Client{
+		Transport: tr,
+		Timeout:   time.Second * 3,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	url := fmt.Sprintf("%s://%s/%s", scheme, location, strings.TrimPrefix(path, "/"))
+	req, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	if hostname != "" {
+		req.Host = hostname
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	capReq := &CapturedRequest{}
+	err = json.NewDecoder(resp.Body).Decode(capReq)
+	if err != nil {
+		body, _ := ioutil.ReadAll(resp.Body)
+		err = fmt.Errorf("unexpected response (statuscode: %d, length: %d): %s", resp.StatusCode, len(body), body)
+		return nil, nil, err
+	}
+
+	capRes := &CapturedResponse{
+		resp.StatusCode,
+		resp.ContentLength,
+		resp.Proto,
+		resp.Header,
+		capturedTLSHostname,
+	}
+	return capReq, capRes, nil
+}


### PR DESCRIPTION
This PR implements the "scenario" steps of the existing feature definitions using the `echoserver` to validate a request roundtrip.

Notes to the reviewers:
- The "background"/"given" steps are not implemented yet. They will be in another PR to keep this one short.
- It is best to ignore the diff in `test/state/state.go` as it is removing the sample imported code.