### PR TITLE
Extending coverage of the feature suite with scenarios from Ingress documentation

### DIFF
--- a/features/default_backend.feature
+++ b/features/default_backend.feature
@@ -16,7 +16,7 @@ Feature: Default backend
           service:
             name: echo-service
             port:
-              number: 80
+              number: 8080
       """
     Then The Ingress status shows the IP address or FQDN where it is exposed
 

--- a/features/host_rules.feature
+++ b/features/host_rules.feature
@@ -21,35 +21,63 @@ Feature: Host rules
               - foo.bar.com
             secretName: conformance-tls
         rules:
-          - host: "*.bar.com"
+          - host: "*.foo.com"
             http:
               paths:
                 - path: /
+                  pathType: Prefix
                   backend:
                     service:
-                      name: host-rules-wildcard-bar-com
+                      name: wildcard-foo-com
                       port:
-                        number: 80
+                        number: 8080
+
           - host: foo.bar.com
             http:
               paths:
-                - backend:
+                - path: /
+                  pathType: Prefix
+                  backend:
                     service:
-                      name: host-rules-foo-bar-com
+                      name: foo-bar-com
                       port:
                         name: http
       """
     Then The Ingress status shows the IP address or FQDN where it is exposed
 
-  Scenario: An Ingress with a host rule should send traffic to the matching backend service
+  Scenario: An Ingress with a host rule should send TLS traffic to the matching backend service
+    (host foo.bar.com matches request foo.bar.com)
     When I send a "GET" request to "https://foo.bar.com"
     Then the secure connection must verify the "foo.bar.com" hostname
     And the response status-code must be 200
-    And the response must be served by the "host-rules-foo-bar-com" service
+    And the response must be served by the "foo-bar-com" service
     And the request host must be "foo.bar.com"
 
+  Scenario: An Ingress with a host rule should send traffic to the matching backend service
+    (host foo.bar.com matches request foo.bar.com)
+    When I send a "GET" request to "http://foo.bar.com"
+    And the response status-code must be 200
+    And the response must be served by the "foo-bar-com" service
+    And the request host must be "foo.bar.com"
+
+  Scenario: An Ingress with a host rule should not route traffic when hostname does not match
+    (host foo.bar.com does not match request subdomain.bar.com)
+    When I send a "GET" request to "http://subdomain.bar.com"
+    Then the response status-code must be 404
+
   Scenario: An Ingress with a wildcard host rule should send traffic to the matching backend service
-    When I send a "GET" request to "http://wildcard.bar.com"
+    (Matches based on shared suffix)
+    When I send a "GET" request to "http://bar.foo.com"
     Then the response status-code must be 200
-    And the response must be served by the "host-rules-wildcard-bar-com" service
-    And the request host must be "wildcard.bar.com"
+    And the response must be served by the "wildcard-foo-com" service
+    And the request host must be "bar.foo.com"
+
+  Scenario: An Ingress with a wildcard host rule should not route traffic matching on more than a single dns label
+    (No match, wildcard only covers a single DNS label)
+    When I send a "GET" request to "http://baz.bar.foo.com"
+    Then the response status-code must be 404
+
+  Scenario: An Ingress with a wildcard host rule should not route traffic matching no dns label
+    (No match, wildcard only covers a single DNS label)
+    When I send a "GET" request to "http://foo.com"
+    Then the response status-code must be 404

--- a/features/path_rules.feature
+++ b/features/path_rules.feature
@@ -15,37 +15,180 @@ Feature: Path rules
         name: path-rules
       spec:
         rules:
-          - host: "path-rules"
+          - host: "exact-path-rules"
+            http:
+              paths:
+                - path: /foo
+                  pathType: Exact
+                  backend:
+                    service:
+                      name: foo-exact
+                      port:
+                        number: 8080
+
+          - host: "prefix-path-rules"
             http:
               paths:
                 - path: /foo
                   pathType: Prefix
                   backend:
                     service:
-                      name: path-rules-foo
+                      name: foo-prefix
                       port:
-                        number: 80
+                        number: 8080
+
+                - path: /aaa/bbb
+                  pathType: Prefix
+                  backend:
+                    service:
+                      name: aaa-slash-bbb-prefix
+                      port:
+                        number: 8080
+
+                - path: /aaa
+                  pathType: Prefix
+                  backend:
+                    service:
+                      name: aaa-prefix
+                      port:
+                        number: 8080
+
+          - host: "mixed-path-rules"
+            http:
+              paths:
+                - path: /foo
+                  pathType: Prefix
+                  backend:
+                    service:
+                      name: foo-prefix
+                      port:
+                        number: 8080
 
                 - path: /foo
                   pathType: Exact
                   backend:
                     service:
-                      name: path-rules-exact
+                      name: foo-exact
                       port:
-                        number: 80
+                        number: 8080
+
+          - host: "trailing-slash-path-rules"
+            http:
+              paths:
+                - path: /aaa/bbb/
+                  pathType: Prefix
+                  backend:
+                    service:
+                      name: aaa-slash-bbb-slash-prefix
+                      port:
+                        number: 8080
+
+                - path: /foo/
+                  pathType: Exact
+                  backend:
+                    service:
+                      name: foo-slash-exact
+                      port:
+                        number: 8080
       """
     Then The Ingress status shows the IP address or FQDN where it is exposed
 
-  Scenario: An Ingress with a prefix path rule without a trailing slash should send traffic to the matching backend service
-  (exact /foo matches request /foo)
-    When I send a "GET" request to "http://path-rules/foo"
+  Scenario: An Ingress with exact path rules should send traffic to the matching backend service
+    (exact /foo matches request /foo)
+    When I send a "GET" request to "http://exact-path-rules/foo"
     Then the response status-code must be 200
-    And the response must be served by the "path-rules-exact" service
+    And the response must be served by the "foo-exact" service
     And the request path must be "/foo"
 
-  Scenario: An Ingress with a prefix path rule with a trailing slash should send traffic to the matching backend service
-  (prefix /foo matches request /foo/)
-    When I send a "GET" request to "http://path-rules/foo/"
+  Scenario: An Ingress with exact path rules should not match requests with trailing slash
+    (exact /foo does not match request /foo/)
+    When I send a "GET" request to "http://exact-path-rules/foo/"
+    Then the response status-code must be 404
+
+  Scenario: An Ingress with exact path rules should be case sensitive
+    (exact /foo does not match request /FOO)
+    When I send a "GET" request to "http://exact-path-rules/FOO"
+    Then the response status-code must be 404
+
+  Scenario: An Ingress with exact path rules should not match any other label
+    (exact /foo does not match request /bar)
+    When I send a "GET" request to "http://exact-path-rules/bar"
+    Then the response status-code must be 404
+
+  Scenario: An Ingress with prefix path rules should send traffic to the matching backend service
+    (prefix /foo matches request /foo)
+    When I send a "GET" request to "http://prefix-path-rules/foo"
     Then the response status-code must be 200
-    And the response must be served by the "path-rules-foo" service
+    And the response must be served by the "foo-prefix" service
+    And the request path must be "/foo"
+
+  Scenario: An Ingress with prefix path rules should ignore the request trailing slash and send traffic to the matching backend service
+    (prefix /foo matches request /foo/)
+    When I send a "GET" request to "http://prefix-path-rules/foo/"
+    Then the response status-code must be 200
+    And the response must be served by the "foo-prefix" service
     And the request path must be "/foo/"
+
+  Scenario: An Ingress with prefix path rules should be case sensitive
+    (prefix /foo does not match request /FOO)
+    When I send a "GET" request to "http://prefix-path-rules/FOO"
+    Then the response status-code must be 404
+
+  Scenario: An Ingress with prefix path rules should match multiple labels, match the longest path, and send traffic to the matching backend service
+  (prefix /aaa/bbb matches request /aaa/bbb)
+    When I send a "GET" request to "http://prefix-path-rules/aaa/bbb"
+    Then the response status-code must be 200
+    And the response must be served by the "aaa-slash-bbb-prefix" service
+    And the request path must be "/aaa/bbb"
+
+  Scenario: An Ingress with prefix path rules should match multiple labels, match the longest path, and subpaths and send traffic to the matching backend service
+  (prefix /aaa/bbb matches request /aaa/bbb/ccc)
+    When I send a "GET" request to "http://prefix-path-rules/aaa/bbb/ccc"
+    Then the response status-code must be 200
+    And the response must be served by the "aaa-slash-bbb-prefix" service
+    And the request path must be "/aaa/bbb/ccc"
+
+  Scenario: An Ingress with prefix path rules should and send traffic to the matching backend service
+  (prefix /aaa matches request /aaa/ccc)
+    When I send a "GET" request to "http://prefix-path-rules/aaa/ccc"
+    Then the response status-code must be 200
+    And the response must be served by the "aaa-prefix" service
+    And the request path must be "/aaa/ccc"
+
+  Scenario: An Ingress with prefix path rules should match each labels string prefix
+  (prefix /aaa does not match request /aaaccc)
+    When I send a "GET" request to "http://prefix-path-rules/aaaccc"
+    Then the response status-code must be 404
+
+  Scenario: An Ingress with prefix path rules should ignore the request trailing slash and send traffic to the matching backend service
+  (prefix /foo matches request /foo/)
+    When I send a "GET" request to "http://prefix-path-rules/foo/"
+    Then the response status-code must be 200
+    And the response must be served by the "foo-prefix" service
+    And the request path must be "/foo/"
+
+  Scenario: An Ingress with mixed path rules should send traffic to the matching backend service where Exact is preferred
+    (exact /foo matches request /foo)
+    When I send a "GET" request to "http://mixed-path-rules/foo"
+    Then the response status-code must be 200
+    And the response must be served by the "foo-exact" service
+    And the request path must be "/foo"
+
+  Scenario: An Ingress with a trailing slashes in a prefix path rule should ignore the trailing slash and send traffic to the matching backend service
+    (prefix /aaa/bbb/ matches request /aaa/bbb)
+    When I send a "GET" request to "http://trailing-slash-path-rules/aaa/bbb"
+    Then the response status-code must be 200
+    And the response must be served by the "aaa-slash-bbb-slash-prefix" service
+    And the request path must be "/aaa/bbb"
+
+  Scenario: An Ingress with a trailing slashes in a prefix path rule should ignore the trailing slash and send traffic to the matching backend service
+    (prefix /aaa/bbb/ matches request /aaa/bbb/)
+    When I send a "GET" request to "http://trailing-slash-path-rules/aaa/bbb/"
+    Then the response status-code must be 200
+    And the response must be served by the "aaa-slash-bbb-slash-prefix" service
+    And the request path must be "/aaa/bbb/"
+
+  Scenario: An Ingress with a trailing slashes in an exact path rule should not match requests without a trailing slash
+    (exact /foo/ does not match request /foo)
+    When I send a "GET" request to "http://trailing-slash-path-rules/foo"
+    Then the response status-code must be 404


### PR DESCRIPTION
Using the [Ingress docs for 1.19](https://github.com/kubernetes/website/pull/21590) samples and specifications to increase the coverage of the conformance test suite with added scenarios.