### PR TITLE
Indent echoserver response

### DIFF
--- a/images/echoserver/echoserver.go
+++ b/images/echoserver/echoserver.go
@@ -93,7 +93,7 @@ func echoHandler(w http.ResponseWriter, r *http.Request) {
 		context,
 	}
 
-	js, err := json.Marshal(requestAssertions)
+	js, err := json.MarshalIndent(requestAssertions, "", " ")
 	if err != nil {
 		processError(w, err, http.StatusInternalServerError)
 		return


### PR DESCRIPTION
This helps when debugging is enabled

```
  Scenario: An Ingress with mixed path rules should send traffic to the matching backend service where Exact is preferred # features/path_rules.feature:181
    When I send a "GET" request to "http://mixed-path-rules/foo"                                                          # feature.go:94 -> sigs.k8s.io/ingress-controller-conformance/test/conformance/pathrules.iSendARequestTo
    Then the response status-code must be 200                                                                             # feature.go:102 -> sigs.k8s.io/ingress-controller-conformance/test/conformance/pathrules.theResponseStatuscodeMustBe
    And the response must be served by the "foo-exact" service                                                            # feature.go:106 -> sigs.k8s.io/ingress-controller-conformance/test/conformance/pathrules.theResponseMustBeServedByTheService
    And the request path must be "/foo"                                                                                   # feature.go:110 -> sigs.k8s.io/ingress-controller-conformance/test/conformance/pathrules.theRequestPathMustBe


Sending request:
> GET /foo HTTP/1.1
> Host: mixed-path-rules
> User-Agent: Go-http-client/1.1
> Accept-Encoding: gzip
> 
> 

Received response:
< HTTP/1.1 200 OK
< Content-Length: 550
< Connection: keep-alive
< Content-Type: application/json
< Date: Tue, 18 Aug 2020 23:57:22 GMT
< Server: nginx/1.19.2
< Vary: Accept-Encoding
< X-Content-Type-Options: nosniff
< 
< {
<  "path": "/foo",
<  "host": "mixed-path-rules",
<  "method": "GET",
<  "proto": "HTTP/1.1",
<  "headers": {
<   "User-Agent": [
<    "Go-http-client/1.1"
<   ],
<   "X-Forwarded-For": [
<    "172.18.0.1"
<   ],
<   "X-Forwarded-Host": [
<    "mixed-path-rules"
<   ],
<   "X-Forwarded-Port": [
<    "80"
<   ],
<   "X-Forwarded-Proto": [
<    "http"
<   ],
<   "X-Real-Ip": [
<    "172.18.0.1"
<   ],
<   "X-Request-Id": [
<    "2065bcfa825661746093d916c25df759"
<   ],
<   "X-Scheme": [
<    "http"
<   ]
<  },
<  "namespace": "ingress-conformance-cwnxb",
<  "ingress": "path-rules",
<  "service": "foo-exact"
< }

```