### PR TITLE
Do not throw an error for mismatching SSL hostname

### DIFF
--- a/test/conformance/hostrules/feature.go
+++ b/test/conformance/hostrules/feature.go
@@ -118,7 +118,17 @@ func iSendARequestTo(method string, rawURL string) error {
 }
 
 func theSecureConnectionMustVerifyTheHostname(hostname string) error {
-	return state.AssertTLSHostname(hostname)
+	err := state.AssertTLSHostname(hostname)
+	if err != nil {
+		return err
+	}
+
+	err = state.AssertResponseCertificate(hostname)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func theResponseStatuscodeMustBe(statusCode int) error {

--- a/test/http/http.go
+++ b/test/http/http.go
@@ -57,11 +57,15 @@ type CapturedResponse struct {
 	Proto         string
 	Headers       map[string][]string
 	TLSHostname   string
+
+	Certificate *x509.Certificate
 }
 
 // CaptureRoundTrip will perform an HTTP request and return the CapturedRequest and CapturedResponse tuple
 func CaptureRoundTrip(method, scheme, hostname, path, location string) (*CapturedRequest, *CapturedResponse, error) {
 	var capturedTLSHostname string
+	var certificate *x509.Certificate
+
 	tr := &http.Transport{
 		DisableCompression: true,
 		TLSClientConfig: &tls.Config{
@@ -77,9 +81,9 @@ func CaptureRoundTrip(method, scheme, hostname, path, location string) (*Capture
 					certs[i] = cert
 				}
 
-				// Verify the certificate Hostname matches the request hostname.
 				capturedTLSHostname = certs[0].DNSNames[0]
-				return certs[0].VerifyHostname(hostname)
+				certificate = certs[0]
+				return nil
 			},
 		},
 	}
@@ -160,6 +164,7 @@ func CaptureRoundTrip(method, scheme, hostname, path, location string) (*Capture
 		resp.Proto,
 		resp.Header,
 		capturedTLSHostname,
+		certificate,
 	}
 
 	return &capReq, capRes, nil

--- a/test/state/state.go
+++ b/test/state/state.go
@@ -167,3 +167,13 @@ func (s *Scenario) AssertRequestHeader(headerKey string, headerValue string) err
 
 	return nil
 }
+
+// AssertResponseCertificate returns nil if the captured certificate for the named host is valid.
+// Otherwise it returns an error describing the mismatch.
+func (s *Scenario) AssertResponseCertificate(hostname string) error {
+	if s.CapturedResponse == nil || s.CapturedResponse.Certificate == nil {
+		return fmt.Errorf("hostname verification requires executing a request and also target an HTTPS URL")
+	}
+
+	return s.CapturedResponse.Certificate.VerifyHostname(hostname)
+}


### PR DESCRIPTION
Remove the certificate validation for a scenario creating a connection to an invalid host:
- what should we check?
- what SSL certificate should return?

(some ingress controllers configure a default SSL certificate)