### PR TITLE
Remove prefix path rule scenario

### DIFF
--- a/features/path_rules.feature
+++ b/features/path_rules.feature
@@ -158,12 +158,6 @@ Feature: Path rules
     Then the response status-code must be 200
     And the response must be served by the "aaa-prefix" service
 
-  Scenario: An Ingress with prefix path rules should match each labels string prefix
-    (prefix /aaa does not match request /aaaccc)
-
-    When I send a "GET" request to "http://prefix-path-rules/aaaccc"
-    Then the response status-code must be 404
-
   Scenario: An Ingress with prefix path rules should ignore the request trailing slash and send traffic to the matching backend service
     (prefix /foo matches request /foo/)
 


### PR DESCRIPTION
According to the KEP, this is the expected behavior:

> A path element refers is the list of labels in the path split by the '/' separator. A request is a match for path p if every p is an element-wise prefix of p of the request path. Note that if the last element of the path is a substring of the last element in request path, it is not a match (e.g. /foo/bar matches /foo/bar/baz, but does not match /foo/barbaz)

https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/20190125-ingress-api-group.md#prefix-match

Now, imposing this behavior in the conformance suite means (at least for ingress-nginx) a breaking change that does not add any benefits. Can we remove this scenario?

cc @bowei @robscott 

~~Note: other ingress controllers like Kong are also impacted by this scenario.~~ [this was an mistake](https://github.com/Kong/kong/blob/c4441f5cca27dfc59e0abcb441d129a2a055949b/spec/fixtures/router_path_handling_tests.lua#L78)