### PR TITLE
Generated self signed certs should be TLS secrets

### DIFF
--- a/test/kubernetes/kubernetes.go
+++ b/test/kubernetes/kubernetes.go
@@ -227,6 +227,7 @@ func NewSelfSignedSecret(c clientset.Interface, namespace, secretName string, ho
 		ObjectMeta: metav1.ObjectMeta{
 			Name: secretName,
 		},
+		Type: corev1.SecretTypeTLS,
 		Data: data,
 	}
 


### PR DESCRIPTION
Currently the generated Opaque secret may not be supported by all
Ingress controllers. Rather than making an Opaque secret that contains
the relevant data by convention, explicilty create a TLS secret to
remove ambiguity.