### PR TITLE
echoserver: update cloudbuild.yaml

### DIFF
--- a/images/echoserver/cloudbuild.yaml
+++ b/images/echoserver/cloudbuild.yaml
@@ -1,17 +1,16 @@
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200422-b25d964'
-    entrypoint: bash
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20220617-174ad91c3a'
+    entrypoint: /buildx-entrypoint
     env:
       - TAG=$_GIT_TAG
-      - BASE_REF=$_PULL_BASE_REF
       - REGISTRY=gcr.io/k8s-staging-ingressconformance
     args:
-    - -c
-    - |
-      gcloud auth configure-docker \
-      && make publish-image
+    - build
+    - --tag=$REGISTRY/echoserver:$TAG
+    - --platform=linux/amd64,linux/arm64
+    - --push
+    - .
 substitutions:
   _GIT_TAG: "12345"
-  _PULL_BASE_REF: "master"


### PR DESCRIPTION
Syntax/patterns from
https://github.com/kubernetes/test-infra/blob/4a4a47219ed11d9b27a9500b0f77431e4e73c579/images/git/cloudbuild.yaml#L2

This allows using buildx. Before we were using a really old builder
version which didn't support it