### PR TITLE
echoserver: fix image substitution

### DIFF
--- a/images/echoserver/cloudbuild.yaml
+++ b/images/echoserver/cloudbuild.yaml
@@ -5,7 +5,7 @@ steps:
     entrypoint: /buildx-entrypoint
     args:
     - build
-    - --tag=gcr.io/$PROJECT_ID/echoserver:$TAG
+    - --tag=gcr.io/$PROJECT_ID/echoserver:$_GIT_TAG
     - --platform=linux/amd64,linux/arm64
     - --push
     - .

--- a/images/echoserver/cloudbuild.yaml
+++ b/images/echoserver/cloudbuild.yaml
@@ -3,12 +3,9 @@ options:
 steps:
   - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20220617-174ad91c3a'
     entrypoint: /buildx-entrypoint
-    env:
-      - TAG=$_GIT_TAG
-      - REGISTRY=gcr.io/k8s-staging-ingressconformance
     args:
     - build
-    - --tag=$REGISTRY/echoserver:$TAG
+    - --tag=gcr.io/$PROJECT_ID/echoserver:$TAG
     - --platform=linux/amd64,linux/arm64
     - --push
     - .


### PR DESCRIPTION
This should fix it once and for all, I hope. I had previously only
partially copied other examples; now we are identical
(https://cs.github.com/ameukam/test-infra/blob/c75172ede6fd1f1d7e42ab1fd37783a5c34c4c3b/images/alpine/cloudbuild.yaml?q=%2Fbuildx-entrypoint,
https://cs.github.com/kubernetes-sigs/aws-iam-authenticator/blob/538f7f4314efd21c6f5deeb8ba7598822b89c949/cloudbuild.yaml?q=%2Fbuildx-entrypoint).

The issue was `$REGISTRY` refers to cloudbuild args. We could use
`$$REGISTRY` (or hardcode), but the common pattern is to just use
`$PROJECT_ID` which I verified in the Prow config is correctly set to
`k8s-staging-ingressconformance`.