### PR TITLE
Increase docker build timeout

### DIFF
--- a/images/echoserver/cloudbuild.yaml
+++ b/images/echoserver/cloudbuild.yaml
@@ -11,3 +11,4 @@ steps:
     - .
 substitutions:
   _GIT_TAG: "12345"
+timeout: 1800s # allow up to 30min, as emulation can be slow


### PR DESCRIPTION
Looks like the current one is timing out, likely since qemu is a bit slow. Copy larger timeout from other example repos.