### PR TITLE
Requests to echoserver can specify response headers to return

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,16 @@ $ curl localhost:3000
 {"TestId":"sample","Path":"/","Host":"localhost:3000","Method":"GET","Proto":"HTTP/1.1","Headers":{"Accept":["*/*"],"User-Agent":["curl/7.54.0"]}}
 
 # You can specify headers that should be returned in the echo response using the `X-Echo-Set-Header` header.
-# This header can be specified multiple times. Values are a header name and value separated by `:`.
+# This header can be specified multiple times if needed. Values are a comma separated list of header names and values separated by `:`.
 # Header name casing is preserved.
-$ curl -i localhost:3000 -H 'X-Echo-Set-Header: X-Foo: value1' -H 'X-Echo-Set-Header: x-bar: value2'
+$ curl -i localhost:3000 -H 'X-Echo-Set-Header: X-Foo: value1' -H 'X-Echo-Set-Header: x-bar: value2,x-bar: value3'
 HTTP/1.1 200 OK
 Content-Type: application/json
 X-Content-Type-Options: nosniff
 X-Foo: value1
-x-bar: value2
-Date: Tue, 08 Nov 2022 18:13:21 GMT
-Content-Length: 299
+x-bar: value2,value3
+Date: Wed, 09 Nov 2022 16:14:04 GMT
+Content-Length: 313
 
 {
  "path": "/",
@@ -66,7 +66,7 @@ Content-Length: 299
   ],
   "X-Echo-Set-Header": [
    "X-Foo: value1",
-   "x-bar: value2"
+   "x-bar: value2,x-bar: value3"
   ]
  },
  "namespace": "",

--- a/README.md
+++ b/README.md
@@ -39,6 +39,41 @@ Reporting TestId 'sample'
 # You can then send test HTTP requests on localhost:3000
 $ curl localhost:3000
 {"TestId":"sample","Path":"/","Host":"localhost:3000","Method":"GET","Proto":"HTTP/1.1","Headers":{"Accept":["*/*"],"User-Agent":["curl/7.54.0"]}}
+
+# You can specify headers that should be returned in the echo response using the `X-Echo-Set-Header` header.
+# This header can be specified multiple times. Values are a header name and value separated by `:`.
+# Header name casing is preserved.
+$ curl -i localhost:3000 -H 'X-Echo-Set-Header: X-Foo: value1' -H 'X-Echo-Set-Header: x-bar: value2'
+HTTP/1.1 200 OK
+Content-Type: application/json
+X-Content-Type-Options: nosniff
+X-Foo: value1
+x-bar: value2
+Date: Tue, 08 Nov 2022 18:13:21 GMT
+Content-Length: 299
+
+{
+ "path": "/",
+ "host": "localhost:3000",
+ "method": "GET",
+ "proto": "HTTP/1.1",
+ "headers": {
+  "Accept": [
+   "*/*"
+  ],
+  "User-Agent": [
+   "curl/7.68.0"
+  ],
+  "X-Echo-Set-Header": [
+   "X-Foo: value1",
+   "x-bar: value2"
+  ]
+ },
+ "namespace": "",
+ "ingress": "",
+ "service": "",
+ "pod": ""
+}
 ```
 
 ---

--- a/images/echoserver/echoserver.go
+++ b/images/echoserver/echoserver.go
@@ -166,10 +166,17 @@ func echoHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func writeEchoResponseHeaders(w http.ResponseWriter, headers http.Header) {
-	for _, headerKV := range headers["X-Echo-Set-Header"] {
-		name, value, _ := strings.Cut(headerKV, ":")
-		// Append directly to the map/slice to preserve casing.
-		w.Header()[name] = append(w.Header()[name], strings.TrimSpace(value))
+	for _, headerKVList := range headers["X-Echo-Set-Header"] {
+		headerKVs := strings.Split(headerKVList, ",")
+		for _, headerKV := range headerKVs {
+			name, value, _ := strings.Cut(strings.TrimSpace(headerKV), ":")
+			// Add directly to the map to preserve casing.
+			if len(w.Header()[name]) == 0 {
+				w.Header()[name] = []string{value}
+			} else {
+				w.Header()[name][0] += "," + strings.TrimSpace(value)
+			}
+		}
 	}
 
 }

--- a/images/echoserver/echoserver.go
+++ b/images/echoserver/echoserver.go
@@ -159,9 +159,19 @@ func echoHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	writeEchoResponseHeaders(w, r.Header)
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Write(js)
+}
+
+func writeEchoResponseHeaders(w http.ResponseWriter, headers http.Header) {
+	for _, headerKV := range headers["X-Echo-Set-Header"] {
+		name, value, _ := strings.Cut(headerKV, ":")
+		// Append directly to the map/slice to preserve casing.
+		w.Header()[name] = append(w.Header()[name], strings.TrimSpace(value))
+	}
+
 }
 
 func processError(w http.ResponseWriter, err error, code int) {


### PR DESCRIPTION
Specified using the X-Echo-Set-Header request header. The header value is a comma separated list of header name and value pairs separated by a colon. Casing of header names to return is preserved for testing that needs this.

Part of https://github.com/kubernetes-sigs/gateway-api/issues/1473
