### PR TITLE
Replace k8s.gcr.io with registry.k8s.io

### DIFF
--- a/test/kubernetes/deployment.go
+++ b/test/kubernetes/deployment.go
@@ -38,7 +38,7 @@ import (
 const EchoService = "echo"
 
 // EchoContainer container image name
-const EchoContainer = "k8s.gcr.io/ingressconformance/echoserver:v0.0.1@sha256:9b34b17f391f87fb2155f01da2f2f90b7a4a5c1110ed84cb5379faa4f570dc52"
+const EchoContainer = "registry.k8s.io/ingressconformance/echoserver:v0.0.1@sha256:9b34b17f391f87fb2155f01da2f2f90b7a4a5c1110ed84cb5379faa4f570dc52"
 
 // NewEchoDeployment creates a new deployment of the echoserver image in a particular namespace.
 func NewEchoDeployment(kubeClientSet kubernetes.Interface, namespace, name, serviceName, servicePortName string, servicePort int32) error {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR replaces all `k8s.gcr.io` references with `registry.k8s.io`. See the linked issue for more details.

**Which issue(s) this PR fixes**:
xref https://github.com/kubernetes/k8s.io/issues/4738

**Release note**:
```
Replace all `k8s.gcr.io` references with `registry.k8s.io`
```