### PR TITLE
Support logging request using `X-Echo-Log-Request` Header

### DIFF
--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2015 The Kubernetes Authors.
 #

--- a/hack/boilerplate/boilerplate.py.txt
+++ b/hack/boilerplate/boilerplate.py.txt
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright YEAR The Kubernetes Authors.
 #

--- a/images/echoserver/echoserver.go
+++ b/images/echoserver/echoserver.go
@@ -182,13 +182,14 @@ func writeEchoResponseHeaders(w http.ResponseWriter, headers http.Header) {
 }
 
 func logRequestAssertions(rs RequestAssertions, w http.ResponseWriter, headers http.Header) {
-	js, err := json.Marshal(rs)
-	if err != nil {
-		processError(w, err, http.StatusInternalServerError)
-		return
-	}
 	_, ok := headers["X-Echo-Log-Request"]
 	if ok {
+		js, err := json.Marshal(rs)
+		if err != nil {
+			processError(w, err, http.StatusInternalServerError)
+			return
+		}
+
 		fmt.Printf("The request is: %v\n", string(js))
 	}
 }

--- a/images/echoserver/echoserver.go
+++ b/images/echoserver/echoserver.go
@@ -152,7 +152,7 @@ func echoHandler(w http.ResponseWriter, r *http.Request) {
 
 		tlsStateToAssertions(r.TLS),
 	}
-
+	logRequestAssertions(requestAssertions, w, r.Header)
 	js, err := json.MarshalIndent(requestAssertions, "", " ")
 	if err != nil {
 		processError(w, err, http.StatusInternalServerError)
@@ -179,6 +179,18 @@ func writeEchoResponseHeaders(w http.ResponseWriter, headers http.Header) {
 		}
 	}
 
+}
+
+func logRequestAssertions(rs RequestAssertions, w http.ResponseWriter, headers http.Header) {
+	js, err := json.Marshal(rs)
+	if err != nil {
+		processError(w, err, http.StatusInternalServerError)
+		return
+	}
+	_, ok := headers["X-Echo-Log-Request"]
+	if ok {
+		fmt.Printf("The request is: %v\n", string(js))
+	}
 }
 
 func processError(w http.ResponseWriter, err error, code int) {

--- a/images/echoserver/echoserver.go
+++ b/images/echoserver/echoserver.go
@@ -30,6 +30,10 @@ import (
 	"strings"
 )
 
+// LogRequestHeader triggers the echo-server to log received request headers
+// when this header is present in the request.
+const LogRequestHeader = "X-Echo-Log-Request"
+
 // RequestAssertions contains information about the request and the Ingress
 type RequestAssertions struct {
 	Path    string              `json:"path"`
@@ -166,7 +170,7 @@ func echoHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func writeEchoResponseHeaders(w http.ResponseWriter, headers http.Header) {
-	for _, headerKVList := range headers["X-Echo-Set-Header"] {
+	for _, headerKVList := range headers[LogRequestHeader] {
 		headerKVs := strings.Split(headerKVList, ",")
 		for _, headerKV := range headerKVs {
 			name, value, _ := strings.Cut(strings.TrimSpace(headerKV), ":")


### PR DESCRIPTION
When sending a request to echo-server with the `X-Echo-Log-Request` header, echo-server will log the request out, allowing us to inspect the received headers from ingress.

This is the first item in https://github.com/kubernetes-sigs/gateway-api/issues/2142