### PR TITLE
Install latest version of reformat-gerkin to fix failing tests

### DIFF
--- a/features/default_backend.feature
+++ b/features/default_backend.feature
@@ -9,13 +9,13 @@ Feature: Default backend
   Background:
     Given a new random namespace
     Given an Ingress resource named "default-backend" with this spec:
-    """
-    defaultBackend:
-      service:
-        name: echo-service
-        port:
-          number: 8080
-    """
+      """
+      defaultBackend:
+        service:
+          name: echo-service
+          port:
+            number: 8080
+      """
     Then The Ingress status shows the IP address or FQDN where it is exposed
 
   Scenario Outline: An Ingress with no rules should send all requests to the default backend

--- a/features/host_rules.feature
+++ b/features/host_rules.feature
@@ -9,39 +9,39 @@ Feature: Host rules
     Given a new random namespace
     Given a self-signed TLS secret named "conformance-tls" for the "foo.bar.com" hostname
     Given an Ingress resource
-    """
-    apiVersion: networking.k8s.io/v1
-    kind: Ingress
-    metadata:
-      name: host-rules
-    spec:
-      tls:
-        - hosts:
-            - foo.bar.com
-          secretName: conformance-tls
-      rules:
-        - host: "*.foo.com"
-          http:
-            paths:
-              - path: /
-                pathType: Prefix
-                backend:
-                  service:
-                    name: wildcard-foo-com
-                    port:
-                      number: 8080
-    
-        - host: foo.bar.com
-          http:
-            paths:
-              - path: /
-                pathType: Prefix
-                backend:
-                  service:
-                    name: foo-bar-com
-                    port:
-                      name: http
-    """
+      """
+      apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      metadata:
+        name: host-rules
+      spec:
+        tls:
+          - hosts:
+              - foo.bar.com
+            secretName: conformance-tls
+        rules:
+          - host: "*.foo.com"
+            http:
+              paths:
+                - path: /
+                  pathType: Prefix
+                  backend:
+                    service:
+                      name: wildcard-foo-com
+                      port:
+                        number: 8080
+
+          - host: foo.bar.com
+            http:
+              paths:
+                - path: /
+                  pathType: Prefix
+                  backend:
+                    service:
+                      name: foo-bar-com
+                      port:
+                        name: http
+      """
     Then The Ingress status shows the IP address or FQDN where it is exposed
 
   Scenario: An Ingress with a host rule should send TLS traffic to the matching backend service

--- a/features/ingress_class.feature
+++ b/features/ingress_class.feature
@@ -8,23 +8,23 @@ Feature: Ingress class
 
   Scenario: An Ingress with an invalid ingress class should not send traffic to the matching backend service
     Given an Ingress resource in a new random namespace
-    """
-    apiVersion: networking.k8s.io/v1
-    kind: Ingress
-    metadata:
-      name: test-ingress-class
-    spec:
-      ingressClassName: some-invalid-class-name
-      rules:
-        - host: "ingress-class"
-          http:
-            paths:
-              - path: /
-                pathType: Prefix
-                backend:
-                  service:
-                    name: ingress-class-prefix
-                    port:
-                      number: 8080
-    """
+      """
+      apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      metadata:
+        name: test-ingress-class
+      spec:
+        ingressClassName: some-invalid-class-name
+        rules:
+          - host: "ingress-class"
+            http:
+              paths:
+                - path: /
+                  pathType: Prefix
+                  backend:
+                    service:
+                      name: ingress-class-prefix
+                      port:
+                        number: 8080
+      """
     Then The Ingress status should not contain the IP address or FQDN

--- a/features/load_balancing.feature
+++ b/features/load_balancing.feature
@@ -6,13 +6,13 @@ Feature: Load Balancing
   Background:
     Given a new random namespace
     Given an Ingress resource named "load-balancing" with this spec:
-    """
-    defaultBackend:
-      service:
-        name: echo-service
-        port:
-          number: 8080
-    """
+      """
+      defaultBackend:
+        service:
+          name: echo-service
+          port:
+            number: 8080
+      """
     Then The Ingress status shows the IP address or FQDN where it is exposed
     Then The backend deployment "echo-service" for the ingress resource is scaled to 10
 

--- a/features/path_rules.feature
+++ b/features/path_rules.feature
@@ -7,89 +7,89 @@ Feature: Path rules
 
   Background:
     Given an Ingress resource in a new random namespace
-    """
-    apiVersion: networking.k8s.io/v1
-    kind: Ingress
-    metadata:
-      name: path-rules
-    spec:
-      rules:
-        - host: "exact-path-rules"
-          http:
-            paths:
-              - path: /foo
-                pathType: Exact
-                backend:
-                  service:
-                    name: foo-exact
-                    port:
-                      number: 8080
-    
-        - host: "prefix-path-rules"
-          http:
-            paths:
-              - path: /foo
-                pathType: Prefix
-                backend:
-                  service:
-                    name: foo-prefix
-                    port:
-                      number: 8080
-    
-              - path: /aaa/bbb
-                pathType: Prefix
-                backend:
-                  service:
-                    name: aaa-slash-bbb-prefix
-                    port:
-                      number: 8080
-    
-              - path: /aaa
-                pathType: Prefix
-                backend:
-                  service:
-                    name: aaa-prefix
-                    port:
-                      number: 8080
-    
-        - host: "mixed-path-rules"
-          http:
-            paths:
-              - path: /foo
-                pathType: Prefix
-                backend:
-                  service:
-                    name: foo-prefix
-                    port:
-                      number: 8080
-    
-              - path: /foo
-                pathType: Exact
-                backend:
-                  service:
-                    name: foo-exact
-                    port:
-                      number: 8080
-    
-        - host: "trailing-slash-path-rules"
-          http:
-            paths:
-              - path: /aaa/bbb/
-                pathType: Prefix
-                backend:
-                  service:
-                    name: aaa-slash-bbb-slash-prefix
-                    port:
-                      number: 8080
-    
-              - path: /foo/
-                pathType: Exact
-                backend:
-                  service:
-                    name: foo-slash-exact
-                    port:
-                      number: 8080
-    """
+      """
+      apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      metadata:
+        name: path-rules
+      spec:
+        rules:
+          - host: "exact-path-rules"
+            http:
+              paths:
+                - path: /foo
+                  pathType: Exact
+                  backend:
+                    service:
+                      name: foo-exact
+                      port:
+                        number: 8080
+
+          - host: "prefix-path-rules"
+            http:
+              paths:
+                - path: /foo
+                  pathType: Prefix
+                  backend:
+                    service:
+                      name: foo-prefix
+                      port:
+                        number: 8080
+
+                - path: /aaa/bbb
+                  pathType: Prefix
+                  backend:
+                    service:
+                      name: aaa-slash-bbb-prefix
+                      port:
+                        number: 8080
+
+                - path: /aaa
+                  pathType: Prefix
+                  backend:
+                    service:
+                      name: aaa-prefix
+                      port:
+                        number: 8080
+
+          - host: "mixed-path-rules"
+            http:
+              paths:
+                - path: /foo
+                  pathType: Prefix
+                  backend:
+                    service:
+                      name: foo-prefix
+                      port:
+                        number: 8080
+
+                - path: /foo
+                  pathType: Exact
+                  backend:
+                    service:
+                      name: foo-exact
+                      port:
+                        number: 8080
+
+          - host: "trailing-slash-path-rules"
+            http:
+              paths:
+                - path: /aaa/bbb/
+                  pathType: Prefix
+                  backend:
+                    service:
+                      name: aaa-slash-bbb-slash-prefix
+                      port:
+                        number: 8080
+
+                - path: /foo/
+                  pathType: Exact
+                  backend:
+                    service:
+                      name: foo-slash-exact
+                      port:
+                        number: 8080
+      """
     Then The Ingress status shows the IP address or FQDN where it is exposed
 
   Scenario: An Ingress with exact path rules should send traffic to the matching backend service

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2015 The Kubernetes Authors.
 #

--- a/hack/boilerplate/boilerplate.py.txt
+++ b/hack/boilerplate/boilerplate.py.txt
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright YEAR The Kubernetes Authors.
 #

--- a/hack/verify-gherkin.sh
+++ b/hack/verify-gherkin.sh
@@ -22,7 +22,7 @@ set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
-pip3 install reformat-gherkin==3.0.1 --ignore-installed PyYAML && make verify-gherkin
+pip3 install reformat-gherkin==3.0.1 --ignore-installed PyYAML
 
 if ! command -v reformat-gherkin --version &> /dev/null; then
   echo "Installation of reformat-gherkin failed. See error above"

--- a/hack/verify-gherkin.sh
+++ b/hack/verify-gherkin.sh
@@ -22,8 +22,10 @@ set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
+pip3 install reformat-gherkin==3.0.1 --ignore-installed PyYAML && make verify-gherkin
+
 if ! command -v reformat-gherkin --version &> /dev/null; then
-  echo "Please install reformat-gherkin running \"pip install reformat-gherkin\""
+  echo "Installation of reformat-gherkin failed. See error above"
   exit 1
 fi
 


### PR DESCRIPTION
I had a discussion with @BenTheElder about the best way to upgrade reformat-gherkin version, and we decided to install the correct version in the source repo script (e.g. [verify-gherkins.sh](https://github.com/kubernetes-sigs/ingress-controller-conformance/blob/master/hack/verify-gherkin.sh)), and point the [yaml config from test-infra](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/ingress-controller-conformance/ingress-controller-conformance.yaml) to that script.